### PR TITLE
Collect /proc/mounts and /etc/fstab artifacts together.

### DIFF
--- a/definitions/linux.yaml
+++ b/definitions/linux.yaml
@@ -163,6 +163,16 @@ labels: [System, Configuration Files]
 supported_os: [Linux]
 urls: ['http://en.wikipedia.org/wiki/Fstab']
 ---
+name: LinuxMountInfo
+doc: Linux mount options.
+sources:
+- type: ARTIFACT
+  attributes:
+    names: [LinuxFstab, LinuxProcMounts]
+labels: [System, Configuration Files]
+supported_os: [Linux]
+urls: ['http://en.wikipedia.org/wiki/Fstab']
+---
 name: LinuxWtmp
 doc: Linux wtmp file.
 sources:

--- a/definitions/linux.yaml
+++ b/definitions/linux.yaml
@@ -43,7 +43,10 @@ doc: All Linux job scheduling files.
 sources:
 - type: ARTIFACT
   attributes:
-    names: [AnacronFiles, LinuxCronTabs, LinuxAtJobs]
+    names:
+      - AnacronFiles
+      - LinuxCronTabs
+      - LinuxAtJobs
 labels: [Configuration Files]
 supported_os: [Linux]
 ---
@@ -168,10 +171,11 @@ doc: Linux mount options.
 sources:
 - type: ARTIFACT
   attributes:
-    names: [LinuxFstab, LinuxProcMounts]
+    names:
+      - LinuxFstab
+      - LinuxProcMounts
 labels: [System, Configuration Files]
 supported_os: [Linux]
-urls: ['http://en.wikipedia.org/wiki/Fstab']
 ---
 name: LinuxWtmp
 doc: Linux wtmp file.
@@ -279,7 +283,10 @@ doc: Services running on a Linux system.
 sources:
 - type: ARTIFACT
   attributes:
-    names: [LinuxXinetd, LinuxLSBInit, LinuxSysVInit]
+    names:
+      - LinuxXinetd
+      - LinuxLSBInit
+      - LinuxSysVInit
 labels: [Configuration Files, System]
 supported_os: [Linux]
 ---

--- a/definitions/linux_proc.yaml
+++ b/definitions/linux_proc.yaml
@@ -165,7 +165,6 @@ sources:
       - 'LinuxNetworkIpForwardingState'
       - 'LinuxNetworkPathFilteringSettings'
       - 'LinuxNetworkRedirectState'
-      - 'LinuxProcMounts'
       - 'LinuxRestrictedDmesgReadPrivileges'
       - 'LinuxRestrictedKernelPointerReadPrivileges'
       - 'LinuxSecureSuidCoreDumps'


### PR DESCRIPTION
Move LinuxProcMounts out of the LinuxProcSysHardeningSettings

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/forensicartifacts/artifacts/64)
<!-- Reviewable:end -->
