### PR TITLE
Typo in WindowsGroupPolicyScripts

### DIFF
--- a/definitions/windows.yaml
+++ b/definitions/windows.yaml
@@ -676,7 +676,7 @@ sources:
 - type: FILE
   attributes:
     paths:
-      - '%%environ_systemdroot%%\GroupPolicy\User\Scripts\scripts.ini'
+      - '%%environ_systemroot%%\GroupPolicy\User\Scripts\scripts.ini'
     separator: '\'
 supported_os: [Windows]
 ---


### PR DESCRIPTION
This breaks GRR unit tests

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/forensicartifacts/artifacts/65)
<!-- Reviewable:end -->
