### PR TITLE
Multiple configs for syslog-ng

### DIFF
--- a/definitions/linux.yaml
+++ b/definitions/linux.yaml
@@ -276,13 +276,14 @@ labels: [Configuration Files, Logs]
 supported_os: [Linux]
 urls: ['http://www.rsyslog.com/doc/rsyslog_conf.html']
 ---
-name: LinuxSyslogNgConfig
-doc: Linux syslog-ng configuration.
+name: LinuxSyslogNgConfigs
+doc: Linux syslog-ng configurations.
 sources:
 - type: FILE
   attributes:
     paths:
       - '/etc/syslog-ng/syslog-ng.conf'
+      - '/etc/syslog-ng/conf-d/*.conf'
 labels: [Configuration Files, Logs]
 supported_os: [Linux]
 urls: ['http://linux.die.net/man/5/syslog-ng.conf']


### PR DESCRIPTION
Not covered in the man page but seems to be utilised on at least Debian/Ubuntu by using a @include "/etc/syslog-ng/conf.d/*.conf" at the end of the primary syslog-ng.conf file.

Sorry for the unnecessary overhead :(

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/forensicartifacts/artifacts/71)
<!-- Reviewable:end -->
