### PR TITLE
Remove users.local_settings

### DIFF
--- a/definitions/webbrowser.yaml
+++ b/definitions/webbrowser.yaml
@@ -223,7 +223,7 @@ sources:
       - '%%users.localappdata%%\Microsoft\Windows\History\Low\History.IE5\index.dat'
       - '%%users.localappdata%%\Microsoft\Windows\History\History.IE5\*\index.dat'
       - '%%users.localappdata%%\Microsoft\Windows\History\Low\History.IE5\*\index.dat'
-      - '%%users.local_settings%%\Application Data\Microsoft\Feeds Cache\index.dat'
+      - '%%users.userprofile%%\Local Settings\Application Data\Microsoft\Feeds Cache\index.dat'
       - '%%users.appdata%%\Microsoft\Windows\IEDownloadHistory\index.dat'
       - '%%users.localappdata%%\Microsoft\Windows\WebCache\WebCacheV*.dat'
 labels: [Browser]

--- a/definitions/windows_bootstrap.yaml
+++ b/definitions/windows_bootstrap.yaml
@@ -114,7 +114,6 @@ provides:
   - users.startup
   - users.homedir
   - users.desktop
-  - users.local_settings
   - users.internet_cache
   - users.localappdata
   - users.localappdata_low


### PR DESCRIPTION
AFAICT local settings is not actually a configurable environment variable, and
is always:

%USERPROFILE%\Local Settings

on the versions of windows where it existed. We never actually populated this
variable in GRR, so I'm going to remove it there as well. This Feeds Cache IE
history location appears to be only for very old versions of windows/IE and
isn't actually listed in the forensicswiki reference.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/forensicartifacts/artifacts/75)
<!-- Reviewable:end -->
