### PR TITLE
Temporarily remove sysvinit from LinuxServices.

### DIFF
--- a/definitions/linux.yaml
+++ b/definitions/linux.yaml
@@ -354,7 +354,6 @@ sources:
     names:
       - LinuxXinetd
       - LinuxLSBInit
-      - LinuxSysVInit
 labels: [Configuration Files, System]
 supported_os: [Linux]
 ---


### PR DESCRIPTION
- Having some parsing issues with this group of artifacts, dropping sysvinit out
  temporarily.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/forensicartifacts/artifacts/82)
<!-- Reviewable:end -->
