### PR TITLE
Add additional paths to LinuxSysVInit for OEL

### DIFF
--- a/definitions/linux.yaml
+++ b/definitions/linux.yaml
@@ -329,10 +329,16 @@ doc: Services started by sysv-style init scripts.
 sources:
 - type: FILE
   attributes:
-    paths: ["/etc/rc*.d", "/etc/rc*.d/*"]
+    paths:
+      - '/etc/rc*.d'
+      - '/etc/rc*.d/*'
+      - '/etc/rc.d/rc*.d/*'
+      - '/etc/rc.d/init.d/*'
 labels: [Configuration Files, System]
 supported_os: [Linux]
-urls: ['http://savannah.nongnu.org/projects/sysvinit']
+urls:
+  - 'http://savannah.nongnu.org/projects/sysvinit'
+  - 'http://docs.oracle.com/cd/E37670_01/E41138/html/ol_svcscripts.html'
 ---
 name: LinuxXinetd
 doc: Linux xinetd configurations.


### PR DESCRIPTION
Oracle Enterprise Linux stores it's rc[0-9].d directories under /etc/rc.d rather than /etc.
e.g. From an OEL system.
-rwxr-xr-x 1 root root 4.3K Jan 19  2011 /etc/rc.d/init.d/ntpd
lrwxrwxrwx 1 root root   14 Jul 29  2013 /etc/rc.d/rc0.d/K74ntpd -> ../init.d/ntpd
lrwxrwxrwx 1 root root   14 Jul 29  2013 /etc/rc.d/rc1.d/K74ntpd -> ../init.d/ntpd
lrwxrwxrwx 1 root root   14 Jul 29  2013 /etc/rc.d/rc2.d/S58ntpd -> ../init.d/ntpd
lrwxrwxrwx 1 root root   14 Jul 29  2013 /etc/rc.d/rc3.d/S58ntpd -> ../init.d/ntpd
lrwxrwxrwx 1 root root   14 Jul 29  2013 /etc/rc.d/rc4.d/S58ntpd -> ../init.d/ntpd
lrwxrwxrwx 1 root root   14 Jul 29  2013 /etc/rc.d/rc5.d/S58ntpd -> ../init.d/ntpd
lrwxrwxrwx 1 root root   14 Jul 29  2013 /etc/rc.d/rc6.d/K74ntpd -> ../init.d/ntpd

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/forensicartifacts/artifacts/97)
<!-- Reviewable:end -->
