### PR TITLE
Add validation to Win Registry Key prefixes

### DIFF
--- a/artifacts/source_type.py
+++ b/artifacts/source_type.py
@@ -165,6 +165,13 @@ class WindowsRegistryKeySourceType(SourceType):
 
   TYPE_INDICATOR = definitions.TYPE_INDICATOR_WINDOWS_REGISTRY_KEY
 
+  VALID_PREFIXES = [
+      r'HKEY_LOCAL_MACHINE',
+      r'HKEY_USERS',
+      r'HKEY_CLASSES_ROOT',
+      r'%%current_control_set%%',
+  ]
+
   def __init__(self, keys=None):
     """Initializes the source type object.
 
@@ -178,8 +185,21 @@ class WindowsRegistryKeySourceType(SourceType):
     if not keys:
       raise errors.FormatError(u'Missing keys value.')
 
+    if not isinstance(keys, list):
+      raise errors.FormatError(u'keys must be a list')
+
+    for key in keys:
+      self.ValidateKey(key)
+
     super(WindowsRegistryKeySourceType, self).__init__()
     self.keys = keys
+
+  @classmethod
+  def ValidateKey(cls, key):
+    for prefix in cls.VALID_PREFIXES:
+      if key.startswith(prefix):
+        return
+    raise errors.FormatError(u'Not a supported registry key prefix, got: {}'.format(key))
 
 
 class WindowsRegistryValueSourceType(SourceType):
@@ -210,6 +230,7 @@ class WindowsRegistryValueSourceType(SourceType):
       if set(pair.keys()) != set(['key', 'value']):
         raise errors.FormatError(u'key_value_pair missing "key" and "value"'
                                  u' keys, got: {}'.format(key_value_pairs))
+      WindowsRegistryKeySourceType.ValidateKey(pair['key'])
 
     super(WindowsRegistryValueSourceType, self).__init__()
     self.key_value_pairs = key_value_pairs

--- a/artifacts/source_type.py
+++ b/artifacts/source_type.py
@@ -196,10 +196,18 @@ class WindowsRegistryKeySourceType(SourceType):
 
   @classmethod
   def ValidateKey(cls, key):
+    """Validates this key against supported key names.
+
+    Args:
+      keys: Key name.
+
+    Raises:
+      FormatError: when key is not supported.
+    """
     for prefix in cls.VALID_PREFIXES:
       if key.startswith(prefix):
         return
-    raise errors.FormatError(u'Not a supported registry key prefix, got: {}'.format(key))
+    raise errors.FormatError(u'Not a supported registry key prefix, got: {0:s}'.format(key))
 
 
 class WindowsRegistryValueSourceType(SourceType):

--- a/definitions/kaspersky_careto.yaml
+++ b/definitions/kaspersky_careto.yaml
@@ -82,9 +82,9 @@ sources:
     key_value_pairs:
     - {key: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Explorer\WindowsUpdate', value: 'CISCNF4654'}
     - {key: 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Explorer\WindowsUpdate', value: 'CISCNF0654'}
-    - {key: 'HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\WindowsUpdate', value: 'CISCNF4654'}
-    - {key: 'HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\WindowsUpdate', value: 'CISCNF0654'}
-    - {key: 'HKEY_CURRENT_USER\Software\Classes\\CLSID\{ECD4FC4D-521C-11D0-B792-00A0C90312E1}', value: 'InprocServer32'}
+    - {key: 'HKEY_USERS\%%users.sid%%\Software\Microsoft\Windows\CurrentVersion\Explorer\WindowsUpdate', value: 'CISCNF4654'}
+    - {key: 'HKEY_USERS\%%users.sid%%\Software\Microsoft\Windows\CurrentVersion\Explorer\WindowsUpdate', value: 'CISCNF0654'}
+    - {key: 'HKEY_USERS\%%users.sid%%\Software\Classes\\CLSID\{ECD4FC4D-521C-11D0-B792-00A0C90312E1}', value: 'InprocServer32'}
     - {key: 'HKEY_LOCAL_MACHINE\Software\Classes\CLSID\{E6BB64BE-0618-4353-9193-0AFE606D6F0C}', value: 'InprocServer32'}
 supported_os: [Windows]
 urls: ['http://www.securelist.com/en/downloads/vlpdfs/unveilingthemask_v1.0.pdf']

--- a/definitions/windows.yaml
+++ b/definitions/windows.yaml
@@ -210,8 +210,8 @@ sources:
 - type: REGISTRY_VALUE
   attributes:
     key_value_pairs:
-      - {key: 'HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\StartPage', value: 'ProgramsCache'}
-      - {key: 'HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\StartPage2', value: 'ProgramsCache'}
+      - {key: 'HKEY_USERS\%%users.sid%%\Software\Microsoft\Windows\CurrentVersion\Explorer\StartPage', value: 'ProgramsCache'}
+      - {key: 'HKEY_USERS\%%users.sid%%\Software\Microsoft\Windows\CurrentVersion\Explorer\StartPage2', value: 'ProgramsCache'}
 supported_os: [Windows]
 urls: ['https://github.com/libyal/winreg-kb/blob/master/documentation/Programs%20Cache%20values.asciidoc']
 ---
@@ -1069,7 +1069,7 @@ sources:
 - type: REGISTRY_VALUE
   attributes:
     key_value_pairs:
-      - {key: 'HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon', value: 'AppSetup'}
+      - {key: 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon', value: 'AppSetup'}
 supported_os: [Windows]
 urls: ['https://technet.microsoft.com/en-us/library/cc939701.aspx']
 ---
@@ -1079,7 +1079,7 @@ sources:
 - type: REGISTRY_VALUE
   attributes:
     key_value_pairs:
-      - {key: 'HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon', value: 'VmApplet'}
+      - {key: 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon', value: 'VmApplet'}
 supported_os: [Windows]
 urls: ['https://technet.microsoft.com/en-us/library/cc939701.aspx']
 ---

--- a/tests/registry_test.py
+++ b/tests/registry_test.py
@@ -69,16 +69,6 @@ class ArtifactDefinitionsRegistryTest(unittest.TestCase):
     with self.assertRaises(TypeError):
       _ = next(generator)
 
-  def testHeadVersion(self):
-    """Tests the ArtifactDefinitionsRegistry functions."""
-    artifact_registry = registry.ArtifactDefinitionsRegistry()
-
-    artifact_reader = reader.YamlArtifactsReader()
-    test_file = os.path.join('test_data', 'definitions.yaml')
-
-    for artifact_definition in artifact_reader.ReadFile(test_file):
-      artifact_registry.RegisterDefinition(artifact_definition)
-
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/registry_test.py
+++ b/tests/registry_test.py
@@ -69,6 +69,16 @@ class ArtifactDefinitionsRegistryTest(unittest.TestCase):
     with self.assertRaises(TypeError):
       _ = next(generator)
 
+  def testHeadVersion(self):
+    """Tests the ArtifactDefinitionsRegistry functions."""
+    artifact_registry = registry.ArtifactDefinitionsRegistry()
+
+    artifact_reader = reader.YamlArtifactsReader()
+    test_file = os.path.join('test_data', 'definitions.yaml')
+
+    for artifact_definition in artifact_reader.ReadFile(test_file):
+      artifact_registry.RegisterDefinition(artifact_definition)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/source_type_test.py
+++ b/tests/source_type_test.py
@@ -44,6 +44,9 @@ class WindowsRegistryKeySourceTypeTest(unittest.TestCase):
     """Tests the __init__ function."""
     source_type.WindowsRegistryKeySourceType(keys=[u'HKEY_LOCAL_MACHINE\\test'])
 
+    with self.assertRaises(errors.FormatError):
+      source_type.WindowsRegistryKeySourceType(keys=u'HKEY_LOCAL_MACHINE\\test')
+
 
 class WindowsRegistryValueSourceTypeTest(unittest.TestCase):
   """Class to test the Windows Registry value source type."""

--- a/tests/source_type_test.py
+++ b/tests/source_type_test.py
@@ -42,7 +42,7 @@ class WindowsRegistryKeySourceTypeTest(unittest.TestCase):
 
   def testInitialize(self):
     """Tests the __init__ function."""
-    source_type.WindowsRegistryKeySourceType(keys=[ur'HKEY_LOCAL_MACHINE\test'])
+    source_type.WindowsRegistryKeySourceType(keys=[u'HKEY_LOCAL_MACHINE\\test'])
 
 
 class WindowsRegistryValueSourceTypeTest(unittest.TestCase):
@@ -51,7 +51,7 @@ class WindowsRegistryValueSourceTypeTest(unittest.TestCase):
   def testInitialize(self):
     """Tests the __init__ function."""
     source_type.WindowsRegistryValueSourceType(
-        key_value_pairs=[{'key': ur'HKEY_LOCAL_MACHINE\test', 'value': u'test'}])
+        key_value_pairs=[{'key': u'HKEY_LOCAL_MACHINE\\test', 'value': u'test'}])
 
     with self.assertRaises(errors.FormatError):
       source_type.WindowsRegistryValueSourceType(

--- a/tests/source_type_test.py
+++ b/tests/source_type_test.py
@@ -42,7 +42,7 @@ class WindowsRegistryKeySourceTypeTest(unittest.TestCase):
 
   def testInitialize(self):
     """Tests the __init__ function."""
-    source_type.WindowsRegistryKeySourceType(keys=[u'test'])
+    source_type.WindowsRegistryKeySourceType(keys=[ur'HKEY_LOCAL_MACHINE\test'])
 
 
 class WindowsRegistryValueSourceTypeTest(unittest.TestCase):
@@ -51,7 +51,7 @@ class WindowsRegistryValueSourceTypeTest(unittest.TestCase):
   def testInitialize(self):
     """Tests the __init__ function."""
     source_type.WindowsRegistryValueSourceType(
-        key_value_pairs=[{'key': u'test', 'value': u'test'}])
+        key_value_pairs=[{'key': ur'HKEY_LOCAL_MACHINE\test', 'value': u'test'}])
 
     with self.assertRaises(errors.FormatError):
       source_type.WindowsRegistryValueSourceType(


### PR DESCRIPTION
Add some extra checks to the reading of windows Registry Keys
* ensure keys is a list for TYPE_INDICATOR_WINDOWS_REGISTRY_KEY
* for each key, ensure it starts with an acceptable prefix (don't us HKLM for example)

Follow-on tweaks to some of the definitions to pass the new verification.

Reviewer: @destijl, @joachimmetz

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/forensicartifacts/artifacts/113)
<!-- Reviewable:end -->
