### PR TITLE
/etc/resolv.conf added to linux artifacts

### DIFF
--- a/definitions/linux.yaml
+++ b/definitions/linux.yaml
@@ -91,6 +91,15 @@ sources:
 labels: [Software]
 supported_os: [Linux]
 ---
+name: DNSResolvConfFile
+doc: DNS Resolver configuration file.
+sources:
+- type: FILE
+  attributes: {paths: ['/etc/resolv.conf']}
+labels: [Configuration Files]
+supported_os: [Linux]
+urls: ['http://man7.org/linux/man-pages/man5/resolv.conf.5.html']
+---
 name: HostAccessPolicyConfiguration
 doc: Linux files related to host access policy configuration.
 sources:
@@ -450,12 +459,3 @@ urls:
   - 'https://www.kernel.org/doc/Documentation/filesystems/sysfs-pci.txt'
   - 'https://wiki.debian.org/HowToIdentifyADevice/PCI'
 supported_os: [Linux]
----
-name: ResolvConfFile
-doc: Resolver configuration file.
-sources:
-- type: FILE
-  attributes: {paths: ['/etc/resolv.conf']}
-labels: [Configuration Files]
-supported_os: [Linux]
-urls: ['http://man7.org/linux/man-pages/man5/resolv.conf.5.html']

--- a/definitions/linux.yaml
+++ b/definitions/linux.yaml
@@ -450,3 +450,12 @@ urls:
   - 'https://www.kernel.org/doc/Documentation/filesystems/sysfs-pci.txt'
   - 'https://wiki.debian.org/HowToIdentifyADevice/PCI'
 supported_os: [Linux]
+---
+name: ResolvConfFile
+doc: Resolver configuration file.
+sources:
+- type: FILE
+  attributes: {paths: ['/etc/resolv.conf']}
+labels: [Configuration Files]
+supported_os: [Linux]
+urls: ['http://man7.org/linux/man-pages/man5/resolv.conf.5.html']


### PR DESCRIPTION
Could be useful to check if a DNS has been changed to one controlled by an attacker.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/forensicartifacts/artifacts/156)
<!-- Reviewable:end -->
