### PR TITLE
Allow source types to be extended by library users

### DIFF
--- a/artifacts/artifact.py
+++ b/artifacts/artifact.py
@@ -50,13 +50,12 @@ class ArtifactDefinition(object):
     if not type_indicator:
       raise errors.FormatError(u'Missing type indicator.')
 
-    source_type_class = source_type.SOURCE_TYPES.get(type_indicator)
-    if source_type_class is None:
+    if type_indicator not in source_type.SOURCE_TYPES:
       raise errors.FormatError(
           u'Unsupported type indicator: {0}.'.format(type_indicator))
 
     try:
-      source_object = source_type_class(**attributes)
+      source_object = source_type.SOURCE_TYPES[type_indicator](**attributes)
     except (TypeError, AttributeError) as e:
       raise errors.FormatError(
           "Invalid artifact definition for {0}: {1}".format(self.name, e))

--- a/artifacts/artifact.py
+++ b/artifacts/artifact.py
@@ -50,35 +50,8 @@ class ArtifactDefinition(object):
     if not type_indicator:
       raise errors.FormatError(u'Missing type indicator.')
 
-    source_type_class = None
-    if type_indicator == definitions.TYPE_INDICATOR_ARTIFACT_GROUP:
-      source_type_class = source_type.ArtifactGroupSourceType
-
-    elif type_indicator == definitions.TYPE_INDICATOR_COMMAND:
-      source_type_class = source_type.CommandSourceType
-
-    elif type_indicator == definitions.TYPE_INDICATOR_COMMAND:
-      source_type_class = source_type.CommandCollectorDefinition
-
-    elif type_indicator == definitions.TYPE_INDICATOR_DIRECTORY:
-      source_type_class = source_type.DirectorySourceType
-
-    elif type_indicator == definitions.TYPE_INDICATOR_FILE:
-      source_type_class = source_type.FileSourceType
-
-    elif type_indicator == definitions.TYPE_INDICATOR_PATH:
-      source_type_class = source_type.PathSourceType
-
-    elif type_indicator == definitions.TYPE_INDICATOR_WINDOWS_REGISTRY_KEY:
-      source_type_class = source_type.WindowsRegistryKeySourceType
-
-    elif type_indicator == definitions.TYPE_INDICATOR_WINDOWS_REGISTRY_VALUE:
-      source_type_class = source_type.WindowsRegistryValueSourceType
-
-    elif type_indicator == definitions.TYPE_INDICATOR_WMI_QUERY:
-      source_type_class = source_type.WMIQuerySourceType
-
-    else:
+    source_type_class = source_type.SOURCE_TYPES.get(type_indicator)
+    if source_type_class is None:
       raise errors.FormatError(
           u'Unsupported type indicator: {0}.'.format(type_indicator))
 

--- a/artifacts/source_type.py
+++ b/artifacts/source_type.py
@@ -271,3 +271,20 @@ class WMIQuerySourceType(SourceType):
     super(WMIQuerySourceType, self).__init__()
     self.query = query
     self.base_object = base_object
+
+
+SOURCE_TYPES = {
+  definitions.TYPE_INDICATOR_ARTIFACT_GROUP: ArtifactGroupSourceType,
+  definitions.TYPE_INDICATOR_COMMAND: CommandSourceType,
+
+  # This seems missing now.
+  # definitions.TYPE_INDICATOR_COMMAND: CommandCollectorDefinition,
+  definitions.TYPE_INDICATOR_DIRECTORY: DirectorySourceType,
+  definitions.TYPE_INDICATOR_FILE: FileSourceType,
+  definitions.TYPE_INDICATOR_PATH: PathSourceType,
+  definitions.TYPE_INDICATOR_WINDOWS_REGISTRY_KEY:
+    WindowsRegistryKeySourceType,
+  definitions.TYPE_INDICATOR_WINDOWS_REGISTRY_VALUE:
+    WindowsRegistryValueSourceType,
+  definitions.TYPE_INDICATOR_WMI_QUERY: WMIQuerySourceType,
+}


### PR DESCRIPTION
This allows library users to add private source types by registering new handlers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/forensicartifacts/artifacts/173)
<!-- Reviewable:end -->
