### PR TITLE
Updated artifact locations

### DIFF
--- a/definitions/webbrowser.yaml
+++ b/definitions/webbrowser.yaml
@@ -457,7 +457,9 @@ sources:
   supported_os: [Linux]
 - type: FILE
   attributes:
-    paths: ['%%users.appdata%%\Opera\Opera\global_history.dat']
+    paths:
+      - '%%users.appdata%%\Opera\Opera\global_history.dat'
+      - '%%users.appdata%%\Roaming\Opera Software\Opera Stable\History'
     separator: '\'
   supported_os: [Windows]
 supported_os: [Windows,Darwin,Linux]

--- a/definitions/webbrowser.yaml
+++ b/definitions/webbrowser.yaml
@@ -273,6 +273,7 @@ sources:
     paths:
       - '%%users.localappdata%%\Mozilla\Firefox\Profiles\*\places.sqlite'
       - '%%users.appdata%%\Mozilla\Firefox\Profiles\*\places.sqlite'
+      - '%%users.appdata%%\Roaming\Mozilla\Firefox\Profiles\*\places.sqlite'
     separator: '\'
   supported_os: [Windows]
 - type: FILE

--- a/definitions/windows.yaml
+++ b/definitions/windows.yaml
@@ -34,7 +34,7 @@ doc: The AMCache.hve Windows NT Registry file.
 sources:
 - type: FILE
   attributes:
-    paths: ['%%environ_systemroot%%\System32\AppCompat\Programs\Amcache.hve']
+    paths: ['%%environ_systemroot%%\AppCompat\Programs\Amcache.hve']
     separator: '\'
 conditions: [os_major_version >= 6 AND os_minor_version >= 1]
 supported_os: [Windows]
@@ -1227,7 +1227,7 @@ doc: The RecentFileCache.bcf file.
 sources:
 - type: FILE
   attributes:
-    paths: ['%%environ_systemroot%%\System32\AppCompat\Programs\RecentFileCache.bcf']
+    paths: ['%%environ_systemroot%%\AppCompat\Programs\RecentFileCache.bcf']
     separator: '\'
 conditions: [os_major_version >= 6 AND os_minor_version >= 1]
 supported_os: [Windows]


### PR DESCRIPTION
The Amcache.hve and RecentFileCache.bcf incorrectly have System32 in the path.  I haven't come across anything or seen a system where that's correct.

Added additional history locations for updated versions of Firefox and Opera.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/forensicartifacts/artifacts/198)
<!-- Reviewable:end -->
