### PR TITLE
Make stats.py work with python 3

### DIFF
--- a/tools/stats.py
+++ b/tools/stats.py
@@ -13,7 +13,7 @@ class ArtifactStatistics(object):
   """Generate and print statistics about artifact files."""
 
   def _PrintDictAsTable(self, src_dict):
-    key_list = src_dict.keys()
+    key_list = list(src_dict.keys())
     key_list.sort()
 
     print('|', end='')


### PR DESCRIPTION
This fixes the following error with python 3:
```
# stats.py 


As of 2016-10-23 the repository contains:

| **File paths covered** | **709** |
| :------------------ | ------: |
| **Registry keys covered** | **429** |
| **Total artifacts** | **415** |

**Artifacts by type**

Traceback (most recent call last):
  File "/usr/local/bin/stats.py", line 106, in <module>
    main()
  File "/usr/local/bin/stats.py", line 102, in main
    statsbuilder.PrintStats()
  File "/usr/local/bin/stats.py", line 95, in PrintStats
    self.PrintSourceTypeTable()
  File "/usr/local/bin/stats.py", line 44, in PrintSourceTypeTable
    self._PrintDictAsTable(self.source_type_counts)
  File "/usr/local/bin/stats.py", line 17, in _PrintDictAsTable
    key_list.sort()
AttributeError: 'dict_keys' object has no attribute 'sort'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/forensicartifacts/artifacts/202)
<!-- Reviewable:end -->
