### PR TITLE
Fix some regression tests with python 3.6.2

### DIFF
--- a/artifacts/reader.py
+++ b/artifacts/reader.py
@@ -129,7 +129,7 @@ class ArtifactsReader(BaseArtifactsReader):
     supported_os = definition_values.get('supported_os', [])
     if not isinstance(supported_os, list):
       raise errors.FormatError(
-          'Invalid supported_os type: {0:s}'.format(type(supported_os)))
+          'Invalid supported_os type: {0!s}'.format(type(supported_os)))
 
     undefined_supported_os = set(supported_os).difference(self.supported_os)
     if undefined_supported_os:
@@ -204,7 +204,7 @@ class ArtifactsReader(BaseArtifactsReader):
     different_keys = (
         set(artifact_definition_values) - definitions.TOP_LEVEL_KEYS)
     if different_keys:
-      raise errors.FormatError('Undefined keys: {0:s}'.format(different_keys))
+      raise errors.FormatError('Undefined keys: {0!s}'.format(different_keys))
 
     name = artifact_definition_values.get('name', None)
     if not name:

--- a/artifacts/reader.py
+++ b/artifacts/reader.py
@@ -204,7 +204,8 @@ class ArtifactsReader(BaseArtifactsReader):
     different_keys = (
         set(artifact_definition_values) - definitions.TOP_LEVEL_KEYS)
     if different_keys:
-      raise errors.FormatError('Undefined keys: {0!s}'.format(different_keys))
+      different_keys = ', '.join(different_keys)
+      raise errors.FormatError('Undefined keys: {0:s}'.format(different_keys))
 
     name = artifact_definition_values.get('name', None)
     if not name:

--- a/artifacts/source_type.py
+++ b/artifacts/source_type.py
@@ -311,7 +311,7 @@ class WindowsRegistryValueSourceType(SourceType):
       if set(pair.keys()) != set(['key', 'value']):
         error_message = (
             'key_value_pair missing "key" and "value" keys, got: '
-            '{0:s}').format(key_value_pairs)
+            '{0!s}').format(key_value_pairs)
         raise errors.FormatError(error_message)
 
       WindowsRegistryKeySourceType.ValidateKey(pair['key'])

--- a/artifacts/source_type.py
+++ b/artifacts/source_type.py
@@ -309,9 +309,12 @@ class WindowsRegistryValueSourceType(SourceType):
         raise errors.FormatError('key_value_pair must be a dict')
 
       if set(pair.keys()) != set(['key', 'value']):
+        key_value_pairs = ', '.join([
+            '{0:s}: {1:s}'.format(key, value) for key, value in key_value_pairs
+        ])
         error_message = (
             'key_value_pair missing "key" and "value" keys, got: '
-            '{0!s}').format(key_value_pairs)
+            '{0:s}').format(key_value_pairs)
         raise errors.FormatError(error_message)
 
       WindowsRegistryKeySourceType.ValidateKey(pair['key'])


### PR DESCRIPTION
Currently some regression tests fail with python 3.6.2:

```
======================================================================
ERROR: testBadKey (reader_test.YamlArtifactsReaderTest)
Tests if top level keys are correct.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/wrkdirs/usr/ports/security/py-artifacts/work/artifacts-20170909/tests/reader_test.py", line 166, in testBadKey
    _ = list(artifact_reader.ReadFileObject(file_object))
  File "./artifacts/reader.py", line 347, in ReadFileObject
    artifact_definition = self.ReadArtifactDefinitionValues(yaml_definition)
  File "./artifacts/reader.py", line 207, in ReadArtifactDefinitionValues
    raise errors.FormatError('Undefined keys: {0:s}'.format(different_keys))
TypeError: unsupported format string passed to set.__format__

======================================================================
ERROR: testBadSupportedOS (reader_test.YamlArtifactsReaderTest)
Tests if supported_os is checked correctly.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/wrkdirs/usr/ports/security/py-artifacts/work/artifacts-20170909/tests/reader_test.py", line 197, in testBadSupportedOS
    _ = list(artifact_reader.ReadFileObject(file_object))
  File "./artifacts/reader.py", line 347, in ReadFileObject
    artifact_definition = self.ReadArtifactDefinitionValues(yaml_definition)
  File "./artifacts/reader.py", line 234, in ReadArtifactDefinitionValues
    self._ReadSupportedOS(artifact_definition_values, artifact_definition, name)
  File "./artifacts/reader.py", line 132, in _ReadSupportedOS
    'Invalid supported_os type: {0:s}'.format(type(supported_os)))
TypeError: unsupported format string passed to type.__format__

======================================================================
ERROR: testInitialize (source_type_test.WindowsRegistryValueSourceTypeTest)
Tests the __init__ function.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/wrkdirs/usr/ports/security/py-artifacts/work/artifacts-20170909/tests/source_type_test.py", line 93, in testInitialize
    key_value_pairs=[key_value_pair])
  File "./artifacts/source_type.py", line 314, in __init__
    '{0:s}').format(key_value_pairs)
TypeError: unsupported format string passed to list.__format__
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/forensicartifacts/artifacts/238)
<!-- Reviewable:end -->
