### PR TITLE
Fix usage of %%users.appdata%%

### DIFF
--- a/data/windows.yaml
+++ b/data/windows.yaml
@@ -1953,8 +1953,8 @@ sources:
 - type: FILE
   attributes:
     paths:
-      - '%%users.appdata%%\Roaming\Microsoft\Office\Recent\*'
-      - '%%users.appdata%%\Roaming\Microsoft\Windows\Recent\*'
+      - '%%users.appdata%%\Microsoft\Office\Recent\*'
+      - '%%users.appdata%%\Microsoft\Windows\Recent\*'
     separator: '\'
 labels: [Users]
 supported_os: [Windows]


### PR DESCRIPTION
When using the variable `%%users.appdata%%`, which is provided in the registry artifact `HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders`, the `Roaming` part is already included. This is consistent with other usages, for example with `users.localappdata`.