### PR TITLE
Add proxy pac "AutoConfigURL" registry artifact

### DIFF
--- a/data/windows.yaml
+++ b/data/windows.yaml
@@ -1298,6 +1298,16 @@ sources:
 supported_os: [Windows]
 urls: ['https://github.com/libyal/winreg-kb/blob/master/documentation/Programs%20Cache%20values.asciidoc']
 ---
+name: WindowsProxyPACAutoConfigURL
+doc: Windows Proxy PAC AutoConfigURL.
+sources:
+- type: REGISTRY_VALUE
+  attributes:
+    key_value_pairs:
+        - {key: 'HKEY_USERS\%%users.sid%%\Software\Microsoft\Windows\CurrentVersion\Internet Settings', value: 'AutoConfigURL'}
+labels: [System, Network]
+supported_os: [Windows]
+---
 name: WindowsRecentFileCacheBCF
 doc: The RecentFileCache.bcf file.
 sources:

--- a/data/windows.yaml
+++ b/data/windows.yaml
@@ -657,7 +657,7 @@ sources:
     separator: '\'
 labels: [Logs]
 supported_os: [Windows]
-urls: 
+urls:
 - 'https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon'
 - 'https://blogs.technet.microsoft.com/motiba/2016/10/18/sysinternals-sysmon-unleashed'
 ---
@@ -1307,6 +1307,7 @@ sources:
         - {key: 'HKEY_USERS\%%users.sid%%\Software\Microsoft\Windows\CurrentVersion\Internet Settings', value: 'AutoConfigURL'}
 labels: [System, Network]
 supported_os: [Windows]
+urls: ['https://blogs.msdn.microsoft.com/askie/2015/07/17/how-can-i-configure-proxy-autoconfigurl-setting-using-group-policy-preference-gpp/']
 ---
 name: WindowsRecentFileCacheBCF
 doc: The RecentFileCache.bcf file.


### PR DESCRIPTION
Added proxy pac into the name so it's easier to find it (e.g. inside GRR). AutoConfigURL is seldom used when searching for that key.