### PR TITLE
Bug fix for LinuxMessagesLogFiles definition

### DIFF
--- a/data/linux.yaml
+++ b/data/linux.yaml
@@ -301,7 +301,7 @@ name: LinuxMessagesLogFiles
 doc: Linux messages log files.
 sources:
 - type: FILE
-  attributes: {paths: ['/var/log/messages.log*']}
+  attributes: {paths: ['/var/log/messages*']}
 labels: [Logs]
 supported_os: [Linux]
 ---


### PR DESCRIPTION
The current definition points to /var/log/messages.log*, but the files are actually named /var/log/messages* (without .log)