### PR TITLE
Add MacOS bash session artifact

### DIFF
--- a/data/macos.yaml
+++ b/data/macos.yaml
@@ -78,6 +78,16 @@ urls:
 - 'http://forensicswiki.org/wiki/Mac_OS_X'
 - 'http://forensicswiki.org/wiki/Mac_OS_X_10.9_-_Artifacts_Location#Logs'
 ---
+name: MacOSBashSessions
+doc: Terminal Commands Sessions
+sources:
+- type: FILE
+  attributes: {paths: ['%%users.homedir%%/.bash_sessions/*']}
+labels: [Users, Logs]
+supported_os: [Darwin]
+urls:
+- 'https://www.swiftforensics.com/2018/05/bash-sessions-in-macos.html'
+---
 name: MacOSBluetoothPlistFile
 doc: Bluetooth preferences and paired device information plist file
 sources:

--- a/data/macos.yaml
+++ b/data/macos.yaml
@@ -85,8 +85,7 @@ sources:
   attributes: {paths: ['%%users.homedir%%/.bash_sessions/*']}
 labels: [Users, Logs]
 supported_os: [Darwin]
-urls:
-- 'https://www.swiftforensics.com/2018/05/bash-sessions-in-macos.html'
+urls: ['https://www.swiftforensics.com/2018/05/bash-sessions-in-macos.html']
 ---
 name: MacOSBluetoothPlistFile
 doc: Bluetooth preferences and paired device information plist file


### PR DESCRIPTION
From the blog post https://www.swiftforensics.com/2018/05/bash-sessions-in-macos.html:

> While all versions of macOS have provided bash_history for users, since macOS 10.11 (El Capitan), we get even more information on terminal history through the bash sessions files. This is not a replacement for the old .bash_history file which is still there.
>
> The location you want to go to is  /Users/\<USER\>/.bash_sessions/*
>
> TERM_SESSION_ID.history    --> Contains session history
TERM_SESSION_ID.historynew --> Mostly blank/empty
TERM_SESSION_ID.session    --> Contains the last session resume date and time
