### PR TITLE
Rename GKE specific artifact and add Docker config

### DIFF
--- a/data/docker.yaml
+++ b/data/docker.yaml
@@ -7,7 +7,7 @@ sources:
   attributes: {paths: ['/var/lib/docker/containers/*/*-json.log*']}
 labels: [Docker, Logs]
 supported_os: [Linux]
-
+---
 name:  DockerContainerConfig
 doc: Docker container configuration files
 sources:

--- a/data/docker.yaml
+++ b/data/docker.yaml
@@ -1,20 +1,21 @@
 # Docker artifacts
 
-name:  GKEDockerContainerLogs
-doc: Location where stdout and stderr from containers is logged in a GKE environment
-sources:
-- type: FILE
-  attributes: {paths: ['/var/lib/docker/containers/*/*-json.log*']}
-labels: [Docker, Logs]
-supported_os: [Linux]
 ---
-name:  DockerContainerConfig
+name: DockerContainerConfig
 doc: Docker container configuration files
 sources:
 - type: FILE
   attributes:
     paths:
-      - '/var/lib/docker/containers/*/config.v2.json'
-      - '/var/lib/docker/containers/*/config.json'
+    - '/var/lib/docker/containers/*/config.v2.json'
+    - '/var/lib/docker/containers/*/config.json'
 labels: [Docker, Configuration Files]
+supported_os: [Linux]
+---
+name: GKEDockerContainerLogs
+doc: Location where stdout and stderr from containers is logged in a Google Kubernetes Engine (GKE) environment.
+sources:
+- type: FILE
+  attributes: {paths: ['/var/lib/docker/containers/*/*-json.log*']}
+labels: [Docker, Logs]
 supported_os: [Linux]

--- a/data/docker.yaml
+++ b/data/docker.yaml
@@ -1,9 +1,20 @@
 # Docker artifacts
 
-name:  DockerContainerLogs
-doc: Location where stdout and stderr from containers is logged
+name:  GKEDockerContainerLogs
+doc: Location where stdout and stderr from containers is logged in a GKE environment
 sources:
 - type: FILE
   attributes: {paths: ['/var/lib/docker/containers/*/*-json.log*']}
 labels: [Docker, Logs]
+supported_os: [Linux]
+
+name:  DockerContainerConfig
+doc: Docker container configuration files
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/var/lib/docker/containers/*/config.v2.json'
+      - '/var/lib/docker/containers/*/config.json'
+labels: [Docker, Configuration Files]
 supported_os: [Linux]


### PR DESCRIPTION
The previous "DockerContainerLogs" artifact is actually specific to Docker installations on a GKE environment.

I'm also adding docker (storage v1 & V2) container configuration files