### PR TITLE
Added artifact labels for plist and SQLite

### DIFF
--- a/artifacts/definitions.py
+++ b/artifacts/definitions.py
@@ -34,11 +34,11 @@ LABELS = {
     'Mail': 'Mail client applications artifacts.',
     'Memory': 'Artifacts retrieved from memory.',
     'Network': 'Describe networking state.',
-    'Plist': 'Plist specific artifact.',
+    'Plist': 'Plist artifact.',
     'Processes': 'Describe running processes.',
     'Rekall': 'Artifacts using the Rekall memory forensics framework.',
     'Software': 'Installed software.',
-    'SQLiteDB': 'SQLite Database specific artifact.',
+    'SQLiteDB': 'SQLite database artifact.',
     'System': 'Core system artifacts.',
     'Users': 'Information about users.'
 }

--- a/artifacts/definitions.py
+++ b/artifacts/definitions.py
@@ -35,7 +35,6 @@ LABELS = {
     'Mail': 'Mail client applications artifacts.',
     'Memory': 'Artifacts retrieved from memory.',
     'Network': 'Describe networking state.',
-    'Persistence': 'Artifact location potentially used for malware persistence.',
     'Plist': 'Plist specific artifact.',
     'Processes': 'Describe running processes.',
     'Rekall': 'Artifacts using the Rekall memory forensics framework.',

--- a/artifacts/definitions.py
+++ b/artifacts/definitions.py
@@ -34,11 +34,11 @@ LABELS = {
     'Mail': 'Mail client applications artifacts.',
     'Memory': 'Artifacts retrieved from memory.',
     'Network': 'Describe networking state.',
-    'Plist': 'Plist artifact.',
+    'Plist': 'Artifact that is a plist.',
     'Processes': 'Describe running processes.',
     'Rekall': 'Artifacts using the Rekall memory forensics framework.',
     'Software': 'Installed software.',
-    'SQLiteDB': 'SQLite database artifact.',
+    'SQLiteDB': 'Artifact that is a SQLite database.',
     'System': 'Core system artifacts.',
     'Users': 'Information about users.'
 }

--- a/artifacts/definitions.py
+++ b/artifacts/definitions.py
@@ -19,6 +19,7 @@ LABELS = {
     'Cloud': 'Cloud applications artifacts.',
     'Cloud Storage': 'Cloud storage artifacts.',
     'Configuration Files': 'Configuration files artifacts.',
+    'DB': 'Database specific artifact',
     'Docker': 'Docker artifacts.',
     'Execution': 'Contain execution events.',
     'ExternalAccount': (
@@ -34,6 +35,8 @@ LABELS = {
     'Mail': 'Mail client applications artifacts.',
     'Memory': 'Artifacts retrieved from memory.',
     'Network': 'Describe networking state.',
+    'Persistence': 'Artifact location potentially used for malware persistence.',
+    'Plist': 'Plist specific artifact.',
     'Processes': 'Describe running processes.',
     'Rekall': 'Artifacts using the Rekall memory forensics framework.',
     'Software': 'Installed software.',

--- a/artifacts/definitions.py
+++ b/artifacts/definitions.py
@@ -19,7 +19,7 @@ LABELS = {
     'Cloud': 'Cloud applications artifacts.',
     'Cloud Storage': 'Cloud storage artifacts.',
     'Configuration Files': 'Configuration files artifacts.',
-    'DB': 'Database specific artifact',
+    'DB': 'Database specific artifact.',
     'Docker': 'Docker artifacts.',
     'Execution': 'Contain execution events.',
     'ExternalAccount': (

--- a/artifacts/definitions.py
+++ b/artifacts/definitions.py
@@ -19,7 +19,6 @@ LABELS = {
     'Cloud': 'Cloud applications artifacts.',
     'Cloud Storage': 'Cloud storage artifacts.',
     'Configuration Files': 'Configuration files artifacts.',
-    'DB': 'Database specific artifact.',
     'Docker': 'Docker artifacts.',
     'Execution': 'Contain execution events.',
     'ExternalAccount': (
@@ -39,6 +38,7 @@ LABELS = {
     'Processes': 'Describe running processes.',
     'Rekall': 'Artifacts using the Rekall memory forensics framework.',
     'Software': 'Installed software.',
+    'SQLiteDB': 'SQLite Database specific artifact.',
     'System': 'Core system artifacts.',
     'Users': 'Information about users.'
 }


### PR DESCRIPTION
I think it would be beneficial to add three new labels for defining artifacts:
- DB and Plist are very useful in a macos (and mobile eventually) environment, where almost all data and configuration are stored in either format. 
- Persistence would be interesting so that we can mark known locations/artifacts of malware persistence mechanisms as such.