### PR TITLE
Replaced skipUnlessHasTestFile decorator with unittest.SkipTest

### DIFF
--- a/tests/reader_test.py
+++ b/tests/reader_test.py
@@ -4,6 +4,7 @@
 from __future__ import unicode_literals
 
 import io
+import os
 import unittest
 import yaml
 
@@ -113,11 +114,13 @@ labels: [Logs]
 supported_os: [Windows]
 """
 
-  @test_lib.skipUnlessHasTestFile(['definitions.yaml'])
   def testReadFileObject(self):
     """Tests the ReadFileObject function."""
-    artifact_reader = reader.YamlArtifactsReader()
     test_file = self._GetTestFilePath(['definitions.yaml'])
+    if not os.path.exists(test_file):
+      raise unittest.SkipTest('missing test file: definitions.yaml')
+
+    artifact_reader = reader.YamlArtifactsReader()
 
     with open(test_file, 'rb') as file_object:
       artifact_definitions = list(artifact_reader.ReadFileObject(file_object))
@@ -315,11 +318,13 @@ supported_os: [Windows]
     with self.assertRaises(errors.FormatError):
       _ = list(artifact_reader.ReadFileObject(file_object))
 
-  @test_lib.skipUnlessHasTestFile(['definitions.yaml'])
   def testReadYamlFile(self):
     """Tests the ReadFile function."""
-    artifact_reader = reader.YamlArtifactsReader()
     test_file = self._GetTestFilePath(['definitions.yaml'])
+    if not os.path.exists(test_file):
+      raise unittest.SkipTest('missing test file: definitions.yaml')
+
+    artifact_reader = reader.YamlArtifactsReader()
 
     artifact_definitions = list(artifact_reader.ReadFile(test_file))
     self.assertEqual(len(artifact_definitions), 7)
@@ -332,11 +337,13 @@ supported_os: [Windows]
     artifact_definitions = list(artifact_reader.ReadDirectory(test_file))
     self.assertEqual(len(artifact_definitions), 7)
 
-  @test_lib.skipUnlessHasTestFile(['definitions.yaml'])
   def testArtifactAsDict(self):
     """Tests the AsDict function."""
-    artifact_reader = reader.YamlArtifactsReader()
     test_file = self._GetTestFilePath(['definitions.yaml'])
+    if not os.path.exists(test_file):
+      raise unittest.SkipTest('missing test file: definitions.yaml')
+
+    artifact_reader = reader.YamlArtifactsReader()
 
     with open(test_file, 'r') as file_object:
       for artifact_definition in yaml.safe_load_all(file_object):
@@ -365,11 +372,13 @@ supported_os: [Windows]
 class JsonArtifactsReaderTest(test_lib.BaseTestCase):
   """JSON artifacts reader tests."""
 
-  @test_lib.skipUnlessHasTestFile(['definitions.json'])
   def testReadJsonFile(self):
     """Tests the ReadFile function."""
-    artifact_reader = reader.JsonArtifactsReader()
     test_file = self._GetTestFilePath(['definitions.json'])
+    if not os.path.exists(test_file):
+      raise unittest.SkipTest('missing test file: definitions.json')
+
+    artifact_reader = reader.JsonArtifactsReader()
 
     artifact_definitions = list(artifact_reader.ReadFile(test_file))
 

--- a/tests/registry_test.py
+++ b/tests/registry_test.py
@@ -4,6 +4,7 @@
 from __future__ import unicode_literals
 
 import io
+import os
 import unittest
 
 from artifacts import errors
@@ -48,13 +49,15 @@ class ArtifactDefinitionsRegistryTest(test_lib.BaseTestCase):
 
   # pylint: disable=protected-access
 
-  @test_lib.skipUnlessHasTestFile(['definitions.yaml'])
   def testArtifactDefinitionsRegistry(self):
     """Tests the ArtifactDefinitionsRegistry functions."""
+    test_file = self._GetTestFilePath(['definitions.yaml'])
+    if not os.path.exists(test_file):
+      raise unittest.SkipTest('missing test file: definitions.yaml')
+
     artifact_registry = registry.ArtifactDefinitionsRegistry()
 
     artifact_reader = reader.YamlArtifactsReader()
-    test_file = self._GetTestFilePath(['definitions.yaml'])
 
     for artifact_definition in artifact_reader.ReadFile(test_file):
       artifact_registry.RegisterDefinition(artifact_definition)

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -9,20 +9,6 @@ import tempfile
 import unittest
 
 
-def GetTestFilePath(path_segments):
-  """Retrieves the path of a test file in the test data directory.
-
-  Args:
-    path_segments (list[str]): path segments inside the test data directory.
-
-  Returns:
-    str: path of the test file.
-  """
-  # Note that we need to pass the individual path segments to os.path.join
-  # and not a list.
-  return os.path.join(os.getcwd(), 'test_data', *path_segments)
-
-
 class BaseTestCase(unittest.TestCase):
   """The base test case."""
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -5,33 +5,8 @@ from __future__ import unicode_literals
 
 import os
 import shutil
-import sys
 import tempfile
 import unittest
-
-
-def skipUnlessHasTestFile(path_segments):  # pylint: disable=invalid-name
-  """Decorator to skip a test if the test file does not exist.
-
-  Args:
-    path_segments (list[str]): path segments inside the test data directory.
-
-  Returns:
-    function: to invoke.
-  """
-  fail_unless_has_test_file = getattr(
-      unittest, 'fail_unless_has_test_file', False)
-
-  path = os.path.join('test_data', *path_segments)
-  if fail_unless_has_test_file or os.path.exists(path):
-    return lambda function: function
-
-  if sys.version_info[0] < 3:
-    path = path.encode('utf-8')
-
-  # Note that the message should be of type str which is different for
-  # different versions of Python.
-  return unittest.skip('missing test file: {0:s}'.format(path))
 
 
 def GetTestFilePath(path_segments):

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -25,6 +25,9 @@ class ArtifactsWriterTest(test_lib.BaseTestCase):
       filename (str): name of the file to convert.
     """
     test_file = self._GetTestFilePath([filename])
+    if not os.path.exists(test_file):
+      raise unittest.SkipTest('missing test file: {0:s}'.format(filename))
+
     artifact_definitions = list(artifact_reader.ReadFile(test_file))
 
     with test_lib.TempDirectory() as temporary_directory:
@@ -39,7 +42,6 @@ class ArtifactsWriterTest(test_lib.BaseTestCase):
         [artifact.AsDict() for artifact in artifact_definitions],
         [artifact.AsDict() for artifact in converted_artifact_definitions])
 
-  @test_lib.skipUnlessHasTestFile(['definitions.json'])
   def testJsonWriter(self):
     """Tests conversion with the JsonArtifactsWriter."""
     artifact_reader = reader.JsonArtifactsReader()
@@ -47,7 +49,6 @@ class ArtifactsWriterTest(test_lib.BaseTestCase):
     self._TestArtifactsConversion(
         artifact_reader, artifact_writer, 'definitions.json')
 
-  @test_lib.skipUnlessHasTestFile(['definitions.yaml'])
   def testYamlWriter(self):
     """Tests conversion with the YamlArtifactsWriter."""
     artifact_reader = reader.YamlArtifactsReader()


### PR DESCRIPTION
skipUnlessHasTestFile decorator conflicts with some build systems replacing by a runtime solution.