### PR TITLE
Add MacOSTCC

### DIFF
--- a/data/macos.yaml
+++ b/data/macos.yaml
@@ -1055,7 +1055,7 @@ urls:
 - 'https://www.sans.org/cyber-security-summit/archives/file/summit-archive-1498158287.pdf'
 ---
 name: MacOSTCC
-doc: Apple's Transparency, Consent, Control framework database
+doc: Apple's Transparency, Consent, Control (TCC) framework database
 sources:
   - type: FILE
     attributes:
@@ -1065,5 +1065,5 @@ sources:
 labels: [System]
 supported_os: [Darwin]
 urls:
-  - https://blog.fleetsmith.com/tcc-a-quick-primer/
-  - https://carlashley.com/2018/09/06/reading-tcc-logs-in-macos/
+- https://blog.fleetsmith.com/tcc-a-quick-primer/
+- https://carlashley.com/2018/09/06/reading-tcc-logs-in-macos/

--- a/data/macos.yaml
+++ b/data/macos.yaml
@@ -1053,3 +1053,17 @@ supported_os: [Darwin]
 urls:
 - 'http://nicoleibrahim.com/apple-fsevents-forensics/'
 - 'https://www.sans.org/cyber-security-summit/archives/file/summit-archive-1498158287.pdf'
+---
+name: MacOSTCC
+doc: Apple's Transparency, Consent, Control framework database
+sources:
+  - type: FILE
+    attributes:
+      paths:
+      - '/Library/Application Support/com.apple.TCC/TCC.db'
+      - '%%users.homedir%%/Library/Application Support/com.apple.TCC/TCC.db'
+labels: [System]
+supported_os: [Darwin]
+urls:
+  - https://blog.fleetsmith.com/tcc-a-quick-primer/
+  - https://carlashley.com/2018/09/06/reading-tcc-logs-in-macos/


### PR DESCRIPTION
Adds an artifact definition for Mojave's Transparency, Consent, and Control framework logs.

References:

  - https://blog.fleetsmith.com/tcc-a-quick-primer/
  - https://carlashley.com/2018/09/06/reading-tcc-logs-in-macos/
