### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,14 @@ jobs:
     python: 3.6
     services:
     - docker
+  - name: "Ubuntu Bionic (18.04) (Docker) with Python 3.6(ppc64le)"
+    env: UBUNTU_VERSION="18.04"
+    group: edge
+    language: python
+    python: 3.6
+    services:
+    - docker
+    arch: ppc64le
   - name: "Ubuntu Focal (20.04) (Docker) with Python 3.8"
     env: UBUNTU_VERSION="20.04"
     group: edge
@@ -39,6 +47,14 @@ jobs:
     python: 3.8
     services:
     - docker
+  - name: "Ubuntu Focal (20.04) (Docker) with Python 3.8(ppc64le)"
+    env: UBUNTU_VERSION="20.04"
+    group: edge
+    language: python
+    python: 3.8
+    services:
+    - docker
+    arch: ppc64le
   - name: "Ubuntu Focal (20.04) (Docker) with Python 3.5 (tox)"
     env:
     - TOXENV="py35"


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/artifacts/builds/190045847 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.
Note: I have added support for only 2 matrix environment.
Thanks !!