### PR TITLE
Update GoogleDrive's Sync log artifact

### DIFF
--- a/data/cloud_services.yaml
+++ b/data/cloud_services.yaml
@@ -43,6 +43,7 @@ sources:
     - '%%users.localappdata%%\Google\Drive\user_default\snapshot.db'
     - '%%users.localappdata%%\Google\Drive\user_default\sync_config.db'
     - '%%users.localappdata%%\Google\Drive\user_default\sync_config.log*'
+    - '%%users.localappdata%%\Google\Drive\user_default\sync_log.log*'
     separator: '\'
   supported_os: [Windows]
 - type: FILE


### PR DESCRIPTION
Examples:
- C:/Users/<user>/AppData/Local/Google/Drive/user_default/sync_log.log
- C:/Users/<user>/AppData/Local/Google/Drive/user_default/sync_log.log.1
- C:/Users/<user>/AppData/Local/Google/Drive/user_default/sync_log.log.2