### PR TITLE
Add note regarding WSL to UsersShellConfigs

### DIFF
--- a/data/unix_common.yaml
+++ b/data/unix_common.yaml
@@ -200,7 +200,7 @@ labels: [Authentication]
 supported_os: [Linux, Darwin]
 ---
 name: UsersShellConfigs
-doc: Common Unix user shell configuration files.
+doc: Common Unix user shell configuration files on *nix or Windows Subsystem for Linux (WSL).
 sources:
 - type: FILE
   attributes:


### PR DESCRIPTION
Add note for WSL because otherwise it can't be found. Filtered in GRR for "WSL", "Linux", "Subsystem", ... found nothing. At least a note for WSL must be there. 

I was searching again for WSL, didn't find anything in the artifacts and then searched through the Github repo for WSL. Found my own contribution (haha). We already worte in the PR about if we should make a note about WSL in the artifact... today, I run into that again. Was already making a new one...

Also, inside GRR I looked first only for Windows artifacts, then switched to all. As I wrote in the PR https://github.com/ForensicArtifacts/artifacts/pull/385 I would move that to Windows because I search there for the WSL part and not in the Unix part.