### PR TITLE
WindowsBITSQueueManagerDatabases: collect recent database too

### DIFF
--- a/data/windows.yaml
+++ b/data/windows.yaml
@@ -265,7 +265,9 @@ doc: Databases that contain the Windows BITS jobs definition and state.
 sources:
 - type: FILE
   attributes:
-    paths: ['%%environ_allusersprofile%%\Microsoft\Network\Downloader\*']
+    paths:
+    - '%%environ_allusersprofile%%\Microsoft\Network\Downloader\qmgr*.dat'
+    - '%%environ_allusersprofile%%\Microsoft\Network\Downloader\qmgr.db'
     separator: '\'
 supported_os: [Windows]
 urls: ['http://dfrws.org/2015/proceedings/presentations/DFRWS2015-pres3.pdf']

--- a/data/windows.yaml
+++ b/data/windows.yaml
@@ -265,7 +265,7 @@ doc: Databases that contain the Windows BITS jobs definition and state.
 sources:
 - type: FILE
   attributes:
-    paths: ['%%environ_allusersprofile%%\Microsoft\Network\Downloader\qmgr*.dat']
+    paths: ['%%environ_allusersprofile%%\Microsoft\Network\Downloader\*']
     separator: '\'
 supported_os: [Windows]
 urls: ['http://dfrws.org/2015/proceedings/presentations/DFRWS2015-pres3.pdf']


### PR DESCRIPTION
On new versions of windows,  qmgr*.dat no longer exists.

Here is what I have on my computer running Windows 10 21H1 :

C:\ProgramData\Microsoft\Network\Downloader>dir /B
edb.chk
edb.log
edb00007.log
edbres00001.jrs
edbres00002.jrs
edbtmp.log
qmgr.db
qmgr.jfm
