### PR TITLE
Added EventLog providers and sources definitions

### DIFF
--- a/artifacts/__init__.py
+++ b/artifacts/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """ForensicArtifacts.com Artifact Repository."""
 
-__version__ = '20211003'
+__version__ = '20211012'

--- a/config/dpkg/changelog
+++ b/config/dpkg/changelog
@@ -1,5 +1,5 @@
-artifacts (20211003-1) unstable; urgency=low
+artifacts (20211012-1) unstable; urgency=low
 
   * Auto-generated
 
- -- Forensic artifacts <forensicartifacts@googlegroups.com>  Sun, 03 Oct 2021 17:56:49 +0200
+ -- Forensic artifacts <forensicartifacts@googlegroups.com>  Tue, 12 Oct 2021 21:04:48 +0200

--- a/data/legacy.yaml
+++ b/data/legacy.yaml
@@ -177,6 +177,15 @@ provides: [environ_allusersappdata]
 supported_os: [Windows]
 urls: ['http://environmentvariables.org/ProgramData']
 ---
+name: WindowsEventLogProviders
+doc: Windows EventLog provider Registry keys, replaced by WindowsEventLogSources.
+sources:
+- type: REGISTRY_KEY
+  attributes:
+    keys: ['HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\EventLog\*\*']
+supported_os: [Windows]
+urls: ['https://winreg-kb.readthedocs.io/en/latest/sources/EventLog-keys.html']
+---
 name: WinPathEnvironmentVariable
 doc: The %PATH% environment variable.
 sources:

--- a/data/windows.yaml
+++ b/data/windows.yaml
@@ -827,8 +827,17 @@ provides: [environ_windir]
 supported_os: [Windows]
 urls: ['https://artifacts-kb.readthedocs.io/en/latest/sources/windows/EnvironmentVariables.html']
 ---
-name: WindowsEventLogProviders
-doc: Windows EventLog provider Registry keys.
+name: WindowsEventLogPublishers
+doc: Windows EventLog publishers (or providers) Registry keys.
+sources:
+- type: REGISTRY_KEY
+  attributes:
+    keys: ['HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\WINEVT\Publishers\*']
+supported_os: [Windows]
+urls: ['https://winreg-kb.readthedocs.io/en/latest/sources/EventLog-keys.html']
+---
+name: WindowsEventLogSources
+doc: Windows EventLog sources Registry keys.
 sources:
 - type: REGISTRY_KEY
   attributes:

--- a/docs/sources/background/Stats.md
+++ b/docs/sources/background/Stats.md
@@ -3,13 +3,13 @@
 The artifact definitions can be found in the [data directory](https://github.com/ForensicArtifacts/artifacts/tree/main/data)
 and the format is described in detail in the [Style Guide](https://artifacts.readthedocs.io/en/latest/sources/Format-specification.html).
 
-Status of the repository as of 2021-10-03
+Status of the repository as of 2021-10-12
 
 Description | Number
 --- | ---
-Number of artifact definitions: | 575
+Number of artifact definitions: | 577
 Number of file paths: | 1222
-Number of Windows Registry key paths: | 677
+Number of Windows Registry key paths: | 679
 
 ### Artifact definition source types
 
@@ -20,7 +20,7 @@ COMMAND | 9
 DIRECTORY | 14
 FILE | 319
 PATH | 8
-REGISTRY_KEY | 51
+REGISTRY_KEY | 53
 REGISTRY_VALUE | 124
 WMI | 26
 


### PR DESCRIPTION
WindowsEventLogProviders is ambiguous since there is an "event sources" Windows Registry key and a "winevt publishers" Windows Registry key.