### PR TITLE
Changed WindowsEventLogs definition to FILE source

### DIFF
--- a/data/windows.yaml
+++ b/data/windows.yaml
@@ -850,15 +850,11 @@ doc: Windows Event logs.
 sources:
 - type: ARTIFACT_GROUP
   attributes:
-    names:
-    - 'WindowsEventLogApplication'
-    - 'WindowsEventLogSecurity'
-    - 'WindowsEventLogSystem'
-    - 'WindowsXMLEventLogApplication'
-    - 'WindowsXMLEventLogSecurity'
-    - 'WindowsXMLEventLogSysmon'
-    - 'WindowsXMLEventLogSystem'
-    - 'WindowsXMLEventLogTerminalServices'
+    paths:
+    - '%%environ_systemroot%%\System32\winevt\Logs\*.evt'
+    - '%%environ_systemroot%%\System32\config\*.evt'
+    - '%%environ_systemroot%%\System32\winevt\Logs\*.evtx'
+    separator: '\'
 labels: [Logs]
 supported_os: [Windows]
 urls: ['https://artifacts-kb.readthedocs.io/en/latest/sources/windows/EventLog.html']

--- a/data/windows.yaml
+++ b/data/windows.yaml
@@ -848,7 +848,7 @@ urls: ['https://winreg-kb.readthedocs.io/en/latest/sources/EventLog-keys.html']
 name: WindowsEventLogs
 doc: Windows Event logs.
 sources:
-- type: PATH
+- type: FILE
   attributes:
     paths:
     - '%%environ_systemroot%%\System32\config\*.evt'

--- a/data/windows.yaml
+++ b/data/windows.yaml
@@ -848,7 +848,7 @@ urls: ['https://winreg-kb.readthedocs.io/en/latest/sources/EventLog-keys.html']
 name: WindowsEventLogs
 doc: Windows Event logs.
 sources:
-- type: ARTIFACT_GROUP
+- type: PATH
   attributes:
     paths:
     - '%%environ_systemroot%%\System32\winevt\Logs\*.evt'

--- a/data/windows.yaml
+++ b/data/windows.yaml
@@ -851,7 +851,6 @@ sources:
 - type: PATH
   attributes:
     paths:
-    - '%%environ_systemroot%%\System32\winevt\Logs\*.evt'
     - '%%environ_systemroot%%\System32\config\*.evt'
     - '%%environ_systemroot%%\System32\winevt\Logs\*.evtx'
     separator: '\'
@@ -864,7 +863,7 @@ doc: Application Windows Event Log.
 sources:
 - type: FILE
   attributes:
-    paths: ['%%environ_systemroot%%\System32\winevt\Logs\AppEvent.evt']
+    paths: ['%%environ_systemroot%%\System32\config\AppEvent.evt']
     separator: '\'
 conditions: [os_major_version < 6]
 labels: [Logs]
@@ -876,7 +875,7 @@ doc: Security Windows Event Log.
 sources:
 - type: FILE
   attributes:
-    paths: ['%%environ_systemroot%%\System32\winevt\Logs\SecEvent.evt']
+    paths: ['%%environ_systemroot%%\System32\config\SecEvent.evt']
     separator: '\'
 conditions: [os_major_version < 6]
 labels: [Logs]
@@ -888,7 +887,7 @@ doc: System Windows Event Log.
 sources:
 - type: FILE
   attributes:
-    paths: ['%%environ_systemroot%%\System32\winevt\Logs\SysEvent.evt']
+    paths: ['%%environ_systemroot%%\System32\config\SysEvent.evt']
     separator: '\'
 conditions: [os_major_version < 6]
 labels: [Logs]


### PR DESCRIPTION
`WindowsEventLogs` artifact only pulls certain type of eventlogs, ex:
WindowsEventLogApplication
WindowsEventLogSecurity
WindowsEventLogSystem
changing it to include other eventlog files (ex: powershell), it will collect any of the .evtx or .evt files on the host in any of the default folders in different win versions, please see: https://artifacts-kb.readthedocs.io/en/latest/sources/windows/EventLog.html