### PR TITLE
Adding Kubernetes artifacts

### DIFF
--- a/artifacts/definitions.py
+++ b/artifacts/definitions.py
@@ -31,6 +31,7 @@ LABELS = {
     'iOS': 'Artifacts related to iOS devices connected to the system.',
     'History Files': 'History files artifacts e.g. .bash_history.',
     'KnowledgeBase': 'Artifacts used in knowledge base generation.',
+    'Kubernetes': 'Kubernetes artifacts',
     'Logs': 'Contain log files.',
     'Mail': 'Mail client applications artifacts.',
     'Memory': 'Artifacts retrieved from memory.',

--- a/data/kubernetes.yaml
+++ b/data/kubernetes.yaml
@@ -1,0 +1,141 @@
+# kubernetes artifacts
+
+name: KubernetesLogs
+doc: Locations of log files that contain generic information about the Kubernetes node.
+sources:
+- type: FILE
+  attributes:
+    paths: ['/var/log/syslog*']
+labels: [Kubernetes, Log]
+supported_os: [Linux]
+---
+name: KubernetesCertificates
+doc: Certificate files that are used for the whole cluster. The files are only present on the control-plane-node.
+sources:
+- type: FILE
+  attributes:
+    paths:
+      - '/etc/kubernetes/controller-manager.conf'
+      - '/etc/kubernetes/admin.conf'
+      - '/etc/kubernetes/kubelet.conf'
+      - '/etc/kubernetes/scheduler.conf'
+labels: [Kubernetes, Configuration Files]
+supported_os: [Linux]
+urls: ['https://kubernetes.io/docs/setup/best-practices/certificates/']
+---
+name: KubernetesClusterDatabase
+doc: |
+  Kubernetes uses etcd as a cluster database.
+  The etcd database is hosted within a pod and can be configured to be deployed as distributed environment or single intance.
+  The databse is mounted from the local file system into the corresponding containers scheduled by the Pod.
+  To examine the database in a post-mortem investigation, the tool etcd-dumb-db (see urls) is recommended.
+  The location only applies to those nodes in a kubernetes cluster, whose kubelet is running the etcd Pod.
+  The database contains information about the clusters state, deployed resourcees and also delete components.
+sources:
+- type: FILE
+  attributes:
+    paths: ['/var/lib/etcd/member/snap/db']
+labels: [Kubernetes, Configuration Files]
+supported_os: [Linux]
+urls:
+- 'https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/'
+- 'https://github.com/etcd-io/etcd'
+- 'https://github.com/etcd-io/etcd/tree/main/tools/etcd-dump-db'
+---
+name: KubernetesKubelet
+doc: Installation path of the Kubernetes Kubelet component. This component is installed on all nodes that are member of a Kubernetes cluster.
+sources:
+- type: PATH
+  attributes:
+    paths: ['/var/lib/kubelet']
+labels: [Kubernetes]
+supported_os: [Linux]
+urls: ['https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/']
+---
+name: KubernetesKubeletConfiguration
+doc: Files that stores the configuration of the local Kubelet.
+sources:
+- type: FILE
+  attributes:
+    paths:
+    -  '/var/lib/kubelet/config.yaml'
+    -  '/etc/kubernetes/kubelet.conf'
+labels: [Kubernetes, Configuration Files]
+supported_os: [Linux]
+urls:
+- 'https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/'
+- 'https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/'
+---
+name: KubernetesKubeletNetworkPKI
+doc: Locations where certificates and other keyfiles are stored that the Kubelet and Kubernetes in general uses to manage its PKI.
+sources:
+- type: PATH
+  attributes:
+    paths:
+    - '/var/lib/kubelet/pki*'
+    - '/etc/kubernetes/pki/ca.crt'
+labels: [Kubernetes, Configuration Files]
+supported_os: [Linux]
+urls:
+- 'https://kubernetes.io/docs/setup/best-practices/certificates/'
+---
+name: KubernetesKubeletPod
+doc: Path where the Kubelet component of Kubernetes stores information about the Pods that were scheduled to run on that particular node of the cluster.
+sources:
+- type: PATH
+  attributes:
+    paths: ['/var/lib/kubelet/pods/*']
+labels: [Kubernetes]
+supported_os: [Linux]
+---
+name: KubernetesKubeletPodManifest
+doc: Location of the manifest file that has been used to deploy a Pod. The manifest contains the Pods specification.
+sources:
+- type: FILE
+  attributes:
+    paths: ['/etc/kubernetes/manifests/*.yaml']
+labels: [Kubernetes]
+supported_os: [Linux]
+---
+name: KubernetesKubeletPodContainer
+doc: |
+  Path where the container resources created within a Pod are located. The Pod itself gets created/scheduled by the Kubelet component.
+  The path 'containers/' does contain a directory for each container scheduled in that pod.
+  In each of that path there is a file located that 
+sources:
+- type: PATH
+  attributes:
+    paths: ['/var/lib/kubelet/pods/<pod_id>/containers/<container_name>/*']
+labels: [Kubernetes]
+supported_os: [Linux]
+---
+name: KubernetesKubeletPodVolumes
+doc: |
+  Holds volumes and other objects that are mounted into the Pod and respectively into the scheduled container(s).
+  The type of volumes (or objects) are identified by the name appended to a tilde.
+  Examples:
+  'volumes/kubernetes.io~projected' -> describes a projected volume
+  'volumes/kubernetes.io~configmap' -> describes a Kubernetes ConfigMap resource
+sources:
+- type: PATH
+  attributes:
+    paths: ['/var/lib/kubelet/pods/<pod_id>/volumes/*']
+labels: [Kubernetes]
+supported_os: [Linux]
+urls:
+- 'https://kubernetes.io/docs/concepts/storage/volumes'
+- 'https://kubernetes.io/docs/concepts/storage/projected-volumes/'
+- 'https://kubernetes.io/docs/concepts/storage/volumes/#configmap'
+---
+name: KubernetesKubeletPodLogs
+doc: Location where the log data of Pods can be found. Includes also redirected STDOut, STDErr and (if applicable) STDIn of container executions.
+sources:
+- type: FILE
+  attributes:
+    paths: ['/var/log/pods/<namespace>_<pod_name>_<pod_id>/<container_name>/<num>.log']
+labels: [Kubernetes, Logs]
+supported_os: [Linux]
+urls:
+- 'https://github.com/kubernetes/kubernetes/pull/74441'
+- 'https://kubernetes.io/docs/concepts/cluster-administration/logging/'
+---

--- a/data/kubernetes.yaml
+++ b/data/kubernetes.yaml
@@ -151,4 +151,3 @@ supported_os: [Linux]
 urls:
 - 'https://github.com/kubernetes/kubernetes/pull/74441'
 - 'https://kubernetes.io/docs/concepts/cluster-administration/logging/'
----

--- a/data/kubernetes.yaml
+++ b/data/kubernetes.yaml
@@ -4,8 +4,7 @@ name: KubernetesLogs
 doc: Locations of log files that contain generic information about the Kubernetes installation on the node.
 sources:
 - type: FILE
-  attributes:
-    paths: ['/var/log/syslog*']
+  attributes: {paths: ['/var/log/syslog*']}
 labels: [Kubernetes, Log]
 supported_os: [Linux]
 ---
@@ -33,8 +32,7 @@ doc: |
   The database contains information about the clusters state, deployed resourcees and also deleted components.
 sources:
 - type: FILE
-  attributes:
-    paths: ['/var/lib/etcd/member/snap/db']
+  attributes: {paths: ['/var/lib/etcd/member/snap/db']}
 labels: [Kubernetes, Configuration Files]
 supported_os: [Linux]
 urls:
@@ -46,8 +44,7 @@ name: KubernetesKubelet
 doc: Installation path of the Kubernetes Kubelet component. This component is installed on all nodes that are member of a Kubernetes cluster.
 sources:
 - type: PATH
-  attributes:
-    paths: ['/var/lib/kubelet']
+  attributes: {paths: ['/var/lib/kubelet']}
 labels: [Kubernetes]
 supported_os: [Linux]
 urls: ['https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/']
@@ -72,7 +69,7 @@ sources:
 - type: PATH
   attributes:
     paths:
-    - '/var/lib/kubelet/pki*'
+    - '/var/lib/kubelet/pki/*'
     - '/etc/kubernetes/pki/ca.crt'
 labels: [Kubernetes, Configuration Files]
 supported_os: [Linux]
@@ -83,8 +80,7 @@ name: KubernetesKubeletPod
 doc: Path where the Kubelet component of Kubernetes stores information about the Pods that were scheduled to run on that particular node of the cluster.
 sources:
 - type: PATH
-  attributes:
-    paths: ['/var/lib/kubelet/pods/*']
+  attributes: {paths: ['/var/lib/kubelet/pods/*']}
 labels: [Kubernetes]
 supported_os: [Linux]
 ---
@@ -92,8 +88,7 @@ name: KubernetesKubeletPodManifest
 doc: Location of the manifest file that has been used to deploy a Pod. The manifest contains the Pods specification.
 sources:
 - type: FILE
-  attributes:
-    paths: ['/etc/kubernetes/manifests/*.yaml']
+  attributes: {paths: ['/etc/kubernetes/manifests/*.yaml']}
 labels: [Kubernetes]
 supported_os: [Linux]
 ---
@@ -103,13 +98,13 @@ doc: |
   The path 'containers/' does contain a directory for each container scheduled in that pod.
   In each of that path there is a file located that gets mounted into the container at path '/dev/termination-log'.
   This is the logfile that stores termination information in case a container terminates. 
-  The id of that file can be correlated to the container runtime installed on the host.
+  The id of that file can be correlated to the container runtime installed on the host to find out the mount configuration.
 sources:
 - type: PATH
-  attributes:
-    paths: ['/var/lib/kubelet/pods/<pod_id>/containers/<container_name>/*']
+  attributes: {paths: ['/var/lib/kubelet/pods/<pod_id>/containers/<container_name>/*']}
 labels: [Kubernetes]
 supported_os: [Linux]
+urls: ['https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#container-v1-core']
 ---
 name: KubernetesKubeletPodVolumes
 doc: |
@@ -120,8 +115,7 @@ doc: |
   'volumes/kubernetes.io~configmap' -> describes a Kubernetes ConfigMap resource
 sources:
 - type: PATH
-  attributes:
-    paths: ['/var/lib/kubelet/pods/<pod_id>/volumes/*']
+  attributes: {paths: ['/var/lib/kubelet/pods/<pod_id>/volumes/*']}
 labels: [Kubernetes]
 supported_os: [Linux]
 urls:
@@ -133,8 +127,7 @@ name: KubernetesKubeletPodLogs
 doc: Location where the log data of Pods can be found. Includes also redirected STDOut, STDErr and (if applicable) STDIn of container executions.
 sources:
 - type: FILE
-  attributes:
-    paths: ['/var/log/pods/<namespace>_<pod_name>_<pod_id>/<container_name>/<num>.log']
+  attributes: {paths: ['/var/log/pods/<namespace>_<pod_name>_<pod_id>/<container_name>/<num>.log']}
 labels: [Kubernetes, Logs]
 supported_os: [Linux]
 urls:

--- a/data/kubernetes.yaml
+++ b/data/kubernetes.yaml
@@ -5,7 +5,7 @@ doc: Locations of log files that contain generic information about the Kubernete
 sources:
 - type: FILE
   attributes: {paths: ['/var/log/syslog*']}
-labels: [Kubernetes, Log]
+labels: [Kubernetes, Logs]
 supported_os: [Linux]
 ---
 name: KubernetesCertificates

--- a/data/kubernetes.yaml
+++ b/data/kubernetes.yaml
@@ -1,4 +1,4 @@
-# kubernetes artifacts
+# Kubernetes artifacts
 
 name: KubernetesLogs
 doc: Locations of log files that contain generic information about the Kubernetes installation on the node.
@@ -9,15 +9,18 @@ labels: [Kubernetes, Log]
 supported_os: [Linux]
 ---
 name: KubernetesCertificates
-doc: Certificate files that are used for the whole cluster. The files are only present on the control-plane-node.
+doc: |
+  Certificate files that are used for the whole cluster.
+  
+  The files are only present on the control-plane-node.
 sources:
 - type: FILE
   attributes:
     paths:
-      - '/etc/kubernetes/controller-manager.conf'
-      - '/etc/kubernetes/admin.conf'
-      - '/etc/kubernetes/kubelet.conf'
-      - '/etc/kubernetes/scheduler.conf'
+    - '/etc/kubernetes/admin.conf'
+    - '/etc/kubernetes/controller-manager.conf'
+    - '/etc/kubernetes/kubelet.conf'
+    - '/etc/kubernetes/scheduler.conf'
 labels: [Kubernetes, Configuration Files]
 supported_os: [Linux]
 urls: ['https://kubernetes.io/docs/setup/best-practices/certificates/']
@@ -25,11 +28,14 @@ urls: ['https://kubernetes.io/docs/setup/best-practices/certificates/']
 name: KubernetesClusterDatabase
 doc: |
   Kubernetes uses etcd as a cluster database.
-  The etcd database is hosted within a pod and can be configured to be deployed as distributed environment or single intance.
-  The database is mounted from the local file system into the corresponding containers scheduled by the Pod.
-  To examine the database in a post-mortem investigation, the tool etcd-dumb-db (see urls) is recommended.
-  The location only applies to those nodes in a kubernetes cluster, whose kubelet is running the etcd Pod.
-  The database contains information about the clusters state, deployed resourcees and also deleted components.
+
+  The etcd database is hosted within a pod and can be configured to be deployed
+  as distributed environment or single intance. The database is mounted from
+  the local file system into the corresponding containers scheduled by the Pod.
+  To examine the database in a post-mortem investigation, the tool etcd-dumb-db
+  is recommended. The location only applies to those nodes in a kubernetes cluster,
+  whose kubelet is running the etcd Pod. The database contains information about
+  the clusters state, deployed resourcees and also deleted components.
 sources:
 - type: FILE
   attributes: {paths: ['/var/lib/etcd/member/snap/db']}
@@ -41,7 +47,10 @@ urls:
 - 'https://github.com/etcd-io/etcd/tree/main/tools/etcd-dump-db'
 ---
 name: KubernetesKubelet
-doc: Installation path of the Kubernetes Kubelet component. This component is installed on all nodes that are member of a Kubernetes cluster.
+doc: |
+  Installation path of the Kubernetes Kubelet component.
+
+  This component is installed on all nodes that are member of a Kubernetes cluster.
 sources:
 - type: PATH
   attributes: {paths: ['/var/lib/kubelet']}
@@ -94,11 +103,15 @@ supported_os: [Linux]
 ---
 name: KubernetesKubeletPodContainer
 doc: |
-  Path where the container resources created within a Pod are located. The Pod itself gets created/scheduled by the Kubelet component.
-  The path 'containers/' does contain a directory for each container scheduled in that pod.
-  In each of that path there is a file located that gets mounted into the container at path '/dev/termination-log'.
-  This is the logfile that stores termination information in case a container terminates. 
-  The id of that file can be correlated to the container runtime installed on the host to find out the mount configuration.
+  Path where the container resources created within a Pod are located.
+  
+  The Pod itself gets created/scheduled by the Kubelet component. The path
+  'containers/' does contain a directory for each container scheduled in that
+  pod. In each of that path there is a file located that gets mounted into
+  the container at path '/dev/termination-log'. This is the logfile that stores
+  termination information in case a container terminates. The pod identifier of
+  that file can be correlated to the container runtime installed on the host to
+  find out the mount configuration.
 sources:
 - type: PATH
   attributes: {paths: ['/var/lib/kubelet/pods/<pod_id>/containers/<container_name>/*']}
@@ -109,10 +122,12 @@ urls: ['https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#con
 name: KubernetesKubeletPodVolumes
 doc: |
   Holds volumes and other objects that are mounted into the Pod and respectively into the scheduled container(s).
+
   The type of volumes (or objects) are identified by the name appended to a tilde.
+
   Examples:
-  'volumes/kubernetes.io~projected' -> describes a projected volume
-  'volumes/kubernetes.io~configmap' -> describes a Kubernetes ConfigMap resource
+  * 'volumes/kubernetes.io~projected' -> describes a projected volume
+  * 'volumes/kubernetes.io~configmap' -> describes a Kubernetes ConfigMap resource
 sources:
 - type: PATH
   attributes: {paths: ['/var/lib/kubelet/pods/<pod_id>/volumes/*']}
@@ -124,7 +139,10 @@ urls:
 - 'https://kubernetes.io/docs/concepts/storage/volumes/#configmap'
 ---
 name: KubernetesKubeletPodLogs
-doc: Location where the log data of Pods can be found. Includes also redirected STDOut, STDErr and (if applicable) STDIn of container executions.
+doc: |
+  Location where the log data of Pods can be found.
+  
+  Includes also redirected stdout, stderr and (if applicable) stdin of container executions.
 sources:
 - type: FILE
   attributes: {paths: ['/var/log/pods/<namespace>_<pod_name>_<pod_id>/<container_name>/<num>.log']}

--- a/data/kubernetes.yaml
+++ b/data/kubernetes.yaml
@@ -1,7 +1,7 @@
 # kubernetes artifacts
 
 name: KubernetesLogs
-doc: Locations of log files that contain generic information about the Kubernetes node.
+doc: Locations of log files that contain generic information about the Kubernetes installation on the node.
 sources:
 - type: FILE
   attributes:
@@ -27,10 +27,10 @@ name: KubernetesClusterDatabase
 doc: |
   Kubernetes uses etcd as a cluster database.
   The etcd database is hosted within a pod and can be configured to be deployed as distributed environment or single intance.
-  The databse is mounted from the local file system into the corresponding containers scheduled by the Pod.
+  The database is mounted from the local file system into the corresponding containers scheduled by the Pod.
   To examine the database in a post-mortem investigation, the tool etcd-dumb-db (see urls) is recommended.
   The location only applies to those nodes in a kubernetes cluster, whose kubelet is running the etcd Pod.
-  The database contains information about the clusters state, deployed resourcees and also delete components.
+  The database contains information about the clusters state, deployed resourcees and also deleted components.
 sources:
 - type: FILE
   attributes:

--- a/data/kubernetes.yaml
+++ b/data/kubernetes.yaml
@@ -78,8 +78,8 @@ sources:
 - type: PATH
   attributes:
     paths:
-    - '/var/lib/kubelet/pki/*'
-    - '/etc/kubernetes/pki/ca.crt'
+    - '/var/lib/kubelet/pki'
+    - '/etc/kubernetes/pki'
 labels: [Kubernetes, Configuration Files]
 supported_os: [Linux]
 urls:
@@ -89,7 +89,7 @@ name: KubernetesKubeletPod
 doc: Path where the Kubelet component of Kubernetes stores information about the Pods that were scheduled to run on that particular node of the cluster.
 sources:
 - type: PATH
-  attributes: {paths: ['/var/lib/kubelet/pods/*']}
+  attributes: {paths: ['/var/lib/kubelet/pods']}
 labels: [Kubernetes]
 supported_os: [Linux]
 ---
@@ -105,6 +105,9 @@ name: KubernetesKubeletPodContainer
 doc: |
   Path where the container resources created within a Pod are located.
   
+  The paths naming would explain as the following:
+  '/var/lib/kubelet/pods/<pod_id>/containers/<container_name>/*'
+
   The Pod itself gets created/scheduled by the Kubelet component. The path
   'containers/' does contain a directory for each container scheduled in that
   pod. In each of that path there is a file located that gets mounted into
@@ -114,7 +117,7 @@ doc: |
   find out the mount configuration.
 sources:
 - type: PATH
-  attributes: {paths: ['/var/lib/kubelet/pods/<pod_id>/containers/<container_name>/*']}
+  attributes: {paths: ['/var/lib/kubelet/pods/*/containers']}
 labels: [Kubernetes]
 supported_os: [Linux]
 urls: ['https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#container-v1-core']
@@ -130,7 +133,7 @@ doc: |
   * 'volumes/kubernetes.io~configmap' -> describes a Kubernetes ConfigMap resource
 sources:
 - type: PATH
-  attributes: {paths: ['/var/lib/kubelet/pods/<pod_id>/volumes/*']}
+  attributes: {paths: ['/var/lib/kubelet/pods/*/volumes/*']}
 labels: [Kubernetes]
 supported_os: [Linux]
 urls:
@@ -142,10 +145,12 @@ name: KubernetesKubeletPodLogs
 doc: |
   Location where the log data of Pods can be found.
   
+  The path's name would contain the folllowing elements:
+  '/var/log/pods/<namespace>_<pod_name>_<pod_id>/<container_name>/<num>.log'
   Includes also redirected stdout, stderr and (if applicable) stdin of container executions.
 sources:
 - type: FILE
-  attributes: {paths: ['/var/log/pods/<namespace>_<pod_name>_<pod_id>/<container_name>/<num>.log']}
+  attributes: {paths: ['/var/log/pods/*/*/*.log']}
 labels: [Kubernetes, Logs]
 supported_os: [Linux]
 urls:

--- a/data/kubernetes.yaml
+++ b/data/kubernetes.yaml
@@ -101,7 +101,9 @@ name: KubernetesKubeletPodContainer
 doc: |
   Path where the container resources created within a Pod are located. The Pod itself gets created/scheduled by the Kubelet component.
   The path 'containers/' does contain a directory for each container scheduled in that pod.
-  In each of that path there is a file located that 
+  In each of that path there is a file located that gets mounted into the container at path '/dev/termination-log'.
+  This is the logfile that stores termination information in case a container terminates. 
+  The id of that file can be correlated to the container runtime installed on the host.
 sources:
 - type: PATH
   attributes:

--- a/data/kubernetes.yaml
+++ b/data/kubernetes.yaml
@@ -1,7 +1,7 @@
 # Kubernetes artifacts
 
 name: KubernetesLogs
-doc: Locations of log files that contain generic information about the Kubernetes installation on the node.
+doc: Log files that contain information about the Kubernetes installation of a node.
 sources:
 - type: FILE
   attributes: {paths: ['/var/log/syslog*']}
@@ -10,9 +10,9 @@ supported_os: [Linux]
 ---
 name: KubernetesCertificates
 doc: |
-  Certificate files that are used for the whole cluster.
+  Certificate files that are used for a Kubernetes cluster.
   
-  The files are only present on the control-plane-node.
+  The files are typically only present on the control-plane node.
 sources:
 - type: FILE
   attributes:
@@ -27,15 +27,15 @@ urls: ['https://kubernetes.io/docs/setup/best-practices/certificates/']
 ---
 name: KubernetesClusterDatabase
 doc: |
-  Kubernetes uses etcd as a cluster database.
+  Kubernetes cluster (etcd) database.
 
-  The etcd database is hosted within a pod and can be configured to be deployed
-  as distributed environment or single intance. The database is mounted from
-  the local file system into the corresponding containers scheduled by the Pod.
-  To examine the database in a post-mortem investigation, the tool etcd-dumb-db
-  is recommended. The location only applies to those nodes in a kubernetes cluster,
-  whose kubelet is running the etcd Pod. The database contains information about
-  the clusters state, deployed resourcees and also deleted components.
+  The cluster database is hosted within a Pod and can be configured to be
+  deployed as distributed environment or single intance. The database is
+  mounted from the local file system into the corresponding containers
+  scheduled by a pod.
+
+  The database contains information about the clusters state, deployed
+  resourcees and also deleted components.
 sources:
 - type: FILE
   attributes: {paths: ['/var/lib/etcd/member/snap/db']}
@@ -48,7 +48,7 @@ urls:
 ---
 name: KubernetesKubelet
 doc: |
-  Installation path of the Kubernetes Kubelet component.
+  Installation path of the (Kubernetes) Kubelet component.
 
   This component is installed on all nodes that are member of a Kubernetes cluster.
 sources:
@@ -59,13 +59,13 @@ supported_os: [Linux]
 urls: ['https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/']
 ---
 name: KubernetesKubeletConfiguration
-doc: Files that stores the configuration of the local Kubelet.
+doc: Files that stores the configuration of the local (Kubernetes) Kubelet.
 sources:
 - type: FILE
   attributes:
     paths:
-    -  '/var/lib/kubelet/config.yaml'
-    -  '/etc/kubernetes/kubelet.conf'
+    - '/var/lib/kubelet/config.yaml'
+    - '/etc/kubernetes/kubelet.conf'
 labels: [Kubernetes, Configuration Files]
 supported_os: [Linux]
 urls:
@@ -73,20 +73,19 @@ urls:
 - 'https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/'
 ---
 name: KubernetesKubeletNetworkPKI
-doc: Locations where certificates and other keyfiles are stored that the Kubelet and Kubernetes in general uses to manage its PKI.
+doc: Certificates and other keyfiles used for Kubelet and Kubernetes general PKI.
 sources:
 - type: PATH
   attributes:
     paths:
-    - '/var/lib/kubelet/pki'
     - '/etc/kubernetes/pki'
+    - '/var/lib/kubelet/pki'
 labels: [Kubernetes, Configuration Files]
 supported_os: [Linux]
-urls:
-- 'https://kubernetes.io/docs/setup/best-practices/certificates/'
+urls: ['https://kubernetes.io/docs/setup/best-practices/certificates']
 ---
 name: KubernetesKubeletPod
-doc: Path where the Kubelet component of Kubernetes stores information about the Pods that were scheduled to run on that particular node of the cluster.
+doc: Path of (Kubernetes) Kubelet component information about Pods scheduled to run on a particular node.
 sources:
 - type: PATH
   attributes: {paths: ['/var/lib/kubelet/pods']}
@@ -94,7 +93,10 @@ labels: [Kubernetes]
 supported_os: [Linux]
 ---
 name: KubernetesKubeletPodManifest
-doc: Location of the manifest file that has been used to deploy a Pod. The manifest contains the Pods specification.
+doc: |
+  Manifest file that has been used to deploy a (Kubernetes) Pod.
+
+  The manifest contains the Pods specification.
 sources:
 - type: FILE
   attributes: {paths: ['/etc/kubernetes/manifests/*.yaml']}
@@ -103,18 +105,19 @@ supported_os: [Linux]
 ---
 name: KubernetesKubeletPodContainer
 doc: |
-  Path where the container resources created within a Pod are located.
+  Path where the container resources created within a (Kubernetes) Pod are located.
   
   The paths naming would explain as the following:
   '/var/lib/kubelet/pods/<pod_id>/containers/<container_name>/*'
 
   The Pod itself gets created/scheduled by the Kubelet component. The path
   'containers/' does contain a directory for each container scheduled in that
-  pod. In each of that path there is a file located that gets mounted into
-  the container at path '/dev/termination-log'. This is the logfile that stores
-  termination information in case a container terminates. The pod identifier of
-  that file can be correlated to the container runtime installed on the host to
-  find out the mount configuration.
+  Pod. In each of that path there is a file located that gets mounted into
+  the container at '/dev/termination-log'.
+  
+  This is the logfile that stores termination information in case a container
+  terminates. The pod identifier of that file can be correlated to the container
+  runtime installed on the host to find out the mount configuration.
 sources:
 - type: PATH
   attributes: {paths: ['/var/lib/kubelet/pods/*/containers']}
@@ -124,7 +127,7 @@ urls: ['https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#con
 ---
 name: KubernetesKubeletPodVolumes
 doc: |
-  Holds volumes and other objects that are mounted into the Pod and respectively into the scheduled container(s).
+  Volumes and other objects that are mounted into a (Kubernetes) Pod and respectively into the scheduled container(s).
 
   The type of volumes (or objects) are identified by the name appended to a tilde.
 
@@ -143,7 +146,7 @@ urls:
 ---
 name: KubernetesKubeletPodLogs
 doc: |
-  Location where the log data of Pods can be found.
+  Location where the log data of (Kubernetes) Pods can be found.
   
   The path's name would contain the folllowing elements:
   '/var/log/pods/<namespace>_<pod_name>_<pod_id>/<container_name>/<num>.log'


### PR DESCRIPTION
Heyho together! 
I am currently finalizing my master thesis about `Kubernetes Forensics` where one objection is the identification and description of forensic artifacts related to Kubernetes.
To identify them, I have used a method of automated differential analysis between two states, mainly working with `Pod` resources. That allows to trace changes on a nodes file system level so that characteristic file changes can be identified and analyzed. 

To bring my results into a usable and understandable format I have chosen to follow your formatting guidelines so that the results can get contributed to the repo. 

I hope that I understood the guidelines correctly and did not mess up completely ... :D 

To mark the purpose/ type of a placeholder in paths i have decided to use the following style:

`attributes: {paths: ['/var/log/pods/<namespace>_<pod_name>_<pod_id>/<container_name>/<num>.log']}`

If `%%` signs should be used instead I can just exchange the characters. 

Looking forward for your feedback! :)

Kind regards,
Christoph