### PR TITLE
Live Response grouping of artifact definitions

### DIFF
--- a/data/live_response.yaml
+++ b/data/live_response.yaml
@@ -1,0 +1,172 @@
+# Live Response specific artifacts.
+---
+name: LRApplicationConfigsAndLogs
+doc: Group of configuration files and logs of installed applications.
+sources:
+- type: ARTIFACT_GROUP
+  attributes:
+    names:
+    - MicrosoftIISLogs
+    - MicrosoftSqlServerErrorLogs
+    - RedisConfigFile
+    - TomcatFiles
+    - TomcatPasswordFile
+supported_os: [Windows]
+---
+name: LRExecution
+doc: Group of process/command execution related artifacts.
+sources:
+- type: ARTIFACT_GROUP
+  attributes:
+    names:
+    - JavaCacheFiles
+#    - ListProcessesGrr
+    - WindowsAMCacheHveFile
+    - WindowsCIMRepositoryFiles
+    - WindowsCrashDumps
+    - WindowsPrefetchFiles
+    - WindowsRecentFileCacheBCF
+    - WindowsStartupInfo
+    - WindowsSuperFetchFiles
+    - WindowsSystemResourceUsageMonitorDatabaseFile
+    - WMICCMRUA
+supported_os: [Windows]
+---
+name: LRExternalMedia
+doc: Group of external media data or events related artifacts.
+sources:
+- type: ARTIFACT_GROUP
+  attributes:
+    names:
+    - WindowsSetupApiLogs
+supported_os: [Windows]
+---
+name: LRFileSystem
+doc: Group of file system related artifacts.
+sources:
+- type: ARTIFACT_GROUP
+  attributes:
+    names:
+#    - EnumerateFilesystemsGrr
+    - NTFSLogFile
+    - NTFSMFTFiles
+supported_os: [Windows]
+---
+name: LRHistoryFiles
+doc: Group of history files related artifacts.
+sources:
+- type: ARTIFACT_GROUP
+  attributes:
+    names:
+    - ShellConfigurationFile
+    - ShellHistoryFile
+    - WindowsPowerShellHistory
+supported_os: [Windows]
+---
+name: LRInteractiveActivity
+doc: Group of interactive user activity related artifacts.
+sources:
+- type: ARTIFACT_GROUP
+  attributes:
+    names:
+    - MicrosoftOfficeAutosave
+    - MicrosoftOfficeMRU
+    - WindowsActivitiesCacheDatabase
+    - WindowsRDPClientBitmapCache
+    - WindowsRecycleBinMetadata
+    - WindowsSearchDatabase
+    - WindowsUserAutomaticDestinationsJumpLists
+    - WindowsUserCustomDestinationsJumpLists
+    - WindowsUserRecentFiles
+supported_os: [Windows]
+---
+name: LRNetwork
+doc: Group of network related artifacts.
+sources:
+- type: ARTIFACT_GROUP
+  attributes:
+    names:
+#    - EnumerateInterfacesGrr
+#    - ListNetworkConnectionsGrr
+    - WindowsFirewallLogFile
+    - WindowsHostsFiles
+supported_os: [Windows]
+---
+name: LRPersistence
+doc: Group of persistence mechanism related artifacts.
+sources:
+- type: ARTIFACT_GROUP
+  attributes:
+    names:
+    - WMIEnumerateASEC
+    - WMIEnumerateCLEC
+    - WindowsApplicationCompatibilityInstalledShimDatabases
+    - WindowsAutoexecBat
+    - WindowsAutorun
+    - WindowsBITSQueueManagerDatabases
+    - WindowsGroupPolicyScripts
+    - WindowsPowerShellDefaultProfiles
+    - WindowsScheduledTasks
+    - WindowsStartupFolders
+    - WindowsWinstart
+supported_os: [Windows]
+---
+name: LRSecurityAgents
+doc: Group of endpoint detection and response related artifacts.
+sources:
+- type: ARTIFACT_GROUP
+  attributes:
+    names:
+#    - Bit9LocalCache
+#    - CrowdStrikeQuarantine
+    - EsetAVQuarantine
+    - MicrosoftAVLogs
+    - MicrosoftAVQuarantine
+    - SophosAVLogs
+    - SophosAVQuarantine
+    - SymantecAVLogs
+    - SymantecAVQuarantine
+supported_os: [Windows]
+---
+name: LRSystemConfiguration
+doc: Group of configuration files related artifacts.
+sources:
+- type: ARTIFACT_GROUP
+  attributes:
+    names:
+    - WindowsRegistryFilesAndTransactionLogs
+    - WindowsSystemRegistryFilesAndTransactionLogsBackup
+supported_os: [Windows]
+---
+name: LRSystemLogs
+doc: Group of system logs related artifacts.
+sources:
+- type: ARTIFACT_GROUP
+  attributes:
+    names:
+    - WindowsUserAccessLogging
+    - WindowsEventLogs
+supported_os: [Windows]
+---
+name: LRWebBrowserExtensions
+doc: Group of web browser extensions related artifacts.
+sources:
+- type: ARTIFACT_GROUP
+  attributes:
+    names:
+    - ChromiumBasedBrowsersExtensions
+    - ChromiumBasedBrowsersExtensionActivity
+    - ChromePreferences
+#    - Crease
+    - FirefoxAddOns
+supported_os: [Windows]
+---
+name: LRWebBrowserHhistory
+doc: Group of web browser history related artifacts.
+sources:
+- type: ARTIFACT_GROUP
+  attributes:
+    names:
+    - BrowserHistory
+    - WindowsCryptnetUrlCacheMetadata
+supported_os: [Windows]

--- a/data/live_response.yaml
+++ b/data/live_response.yaml
@@ -1,6 +1,6 @@
 # Live Response specific artifacts.
 ---
-name: LRApplicationConfigsAndLogs
+name: LiveResponseApplicationConfigsAndLogs
 doc: Group of configuration files and logs of installed applications.
 sources:
 - type: ARTIFACT_GROUP
@@ -13,14 +13,13 @@ sources:
     - TomcatPasswordFile
 supported_os: [Windows]
 ---
-name: LRExecution
+name: LiveResponseExecution
 doc: Group of process/command execution related artifacts.
 sources:
 - type: ARTIFACT_GROUP
   attributes:
     names:
     - JavaCacheFiles
-#    - ListProcessesGrr
     - WindowsAMCacheHveFile
     - WindowsCIMRepositoryFiles
     - WindowsCrashDumps
@@ -32,7 +31,7 @@ sources:
     - WMICCMRUA
 supported_os: [Windows]
 ---
-name: LRExternalMedia
+name: LiveResponseExternalMedia
 doc: Group of external media data or events related artifacts.
 sources:
 - type: ARTIFACT_GROUP
@@ -41,18 +40,17 @@ sources:
     - WindowsSetupApiLogs
 supported_os: [Windows]
 ---
-name: LRFileSystem
+name: LiveResponseFileSystem
 doc: Group of file system related artifacts.
 sources:
 - type: ARTIFACT_GROUP
   attributes:
     names:
-#    - EnumerateFilesystemsGrr
     - NTFSLogFile
     - NTFSMFTFiles
 supported_os: [Windows]
 ---
-name: LRHistoryFiles
+name: LiveResponseHistoryFiles
 doc: Group of history files related artifacts.
 sources:
 - type: ARTIFACT_GROUP
@@ -63,7 +61,7 @@ sources:
     - WindowsPowerShellHistory
 supported_os: [Windows]
 ---
-name: LRInteractiveActivity
+name: LiveResponseInteractiveActivity
 doc: Group of interactive user activity related artifacts.
 sources:
 - type: ARTIFACT_GROUP
@@ -80,19 +78,17 @@ sources:
     - WindowsUserRecentFiles
 supported_os: [Windows]
 ---
-name: LRNetwork
+name: LiveResponseNetwork
 doc: Group of network related artifacts.
 sources:
 - type: ARTIFACT_GROUP
   attributes:
     names:
-#    - EnumerateInterfacesGrr
-#    - ListNetworkConnectionsGrr
     - WindowsFirewallLogFile
     - WindowsHostsFiles
 supported_os: [Windows]
 ---
-name: LRPersistence
+name: LiveResponsePersistence
 doc: Group of persistence mechanism related artifacts.
 sources:
 - type: ARTIFACT_GROUP
@@ -111,14 +107,12 @@ sources:
     - WindowsWinstart
 supported_os: [Windows]
 ---
-name: LRSecurityAgents
+name: LiveResponseSecurityAgents
 doc: Group of endpoint detection and response related artifacts.
 sources:
 - type: ARTIFACT_GROUP
   attributes:
     names:
-#    - Bit9LocalCache
-#    - CrowdStrikeQuarantine
     - EsetAVQuarantine
     - MicrosoftAVLogs
     - MicrosoftAVQuarantine
@@ -128,7 +122,7 @@ sources:
     - SymantecAVQuarantine
 supported_os: [Windows]
 ---
-name: LRSystemConfiguration
+name: LiveResponseSystemConfiguration
 doc: Group of configuration files related artifacts.
 sources:
 - type: ARTIFACT_GROUP
@@ -138,7 +132,7 @@ sources:
     - WindowsSystemRegistryFilesAndTransactionLogsBackup
 supported_os: [Windows]
 ---
-name: LRSystemLogs
+name: LiveResponseSystemLogs
 doc: Group of system logs related artifacts.
 sources:
 - type: ARTIFACT_GROUP
@@ -148,7 +142,7 @@ sources:
     - WindowsEventLogs
 supported_os: [Windows]
 ---
-name: LRWebBrowserExtensions
+name: LiveResponseWebBrowserExtensions
 doc: Group of web browser extensions related artifacts.
 sources:
 - type: ARTIFACT_GROUP
@@ -160,7 +154,7 @@ sources:
     - FirefoxAddOns
 supported_os: [Windows]
 ---
-name: LRWebBrowserHhistory
+name: LiveResponseWebBrowserHhistory
 doc: Group of web browser history related artifacts.
 sources:
 - type: ARTIFACT_GROUP

--- a/data/live_response.yaml
+++ b/data/live_response.yaml
@@ -157,7 +157,6 @@ sources:
     - ChromiumBasedBrowsersExtensions
     - ChromiumBasedBrowsersExtensionActivitySQLiteDatabaseFile
     - ChromePreferences
-#    - Crease
     - FirefoxAddOns
 supported_os: [Windows]
 ---

--- a/data/live_response.yaml
+++ b/data/live_response.yaml
@@ -155,7 +155,7 @@ sources:
   attributes:
     names:
     - ChromiumBasedBrowsersExtensions
-    - ChromiumBasedBrowsersExtensionActivity
+    - ChromiumBasedBrowsersExtensionActivitySQLiteDatabaseFile
     - ChromePreferences
 #    - Crease
     - FirefoxAddOns

--- a/data/triage.yaml
+++ b/data/triage.yaml
@@ -1,6 +1,6 @@
-# Live Response specific artifacts.
+# Triage specific artifacts.
 ---
-name: LiveResponseApplicationConfigsAndLogs
+name: TriageApplicationConfigsAndLogs
 doc: Group of configuration files and logs of installed applications.
 sources:
 - type: ARTIFACT_GROUP
@@ -13,7 +13,7 @@ sources:
     - TomcatPasswordFile
 supported_os: [Windows]
 ---
-name: LiveResponseExecution
+name: TriageExecution
 doc: Group of process/command execution related artifacts.
 sources:
 - type: ARTIFACT_GROUP
@@ -31,7 +31,7 @@ sources:
     - WMICCMRUA
 supported_os: [Windows]
 ---
-name: LiveResponseExternalMedia
+name: TriageExternalMedia
 doc: Group of external media data or events related artifacts.
 sources:
 - type: ARTIFACT_GROUP
@@ -40,7 +40,7 @@ sources:
     - WindowsSetupApiLogs
 supported_os: [Windows]
 ---
-name: LiveResponseFileSystem
+name: TriageFileSystem
 doc: Group of file system related artifacts.
 sources:
 - type: ARTIFACT_GROUP
@@ -50,7 +50,7 @@ sources:
     - NTFSMFTFiles
 supported_os: [Windows]
 ---
-name: LiveResponseHistoryFiles
+name: TriageHistoryFiles
 doc: Group of history files related artifacts.
 sources:
 - type: ARTIFACT_GROUP
@@ -61,7 +61,7 @@ sources:
     - WindowsPowerShellHistory
 supported_os: [Windows]
 ---
-name: LiveResponseInteractiveActivity
+name: TriageInteractiveActivity
 doc: Group of interactive user activity related artifacts.
 sources:
 - type: ARTIFACT_GROUP
@@ -78,7 +78,7 @@ sources:
     - WindowsUserRecentFiles
 supported_os: [Windows]
 ---
-name: LiveResponseNetwork
+name: TriageNetwork
 doc: Group of network related artifacts.
 sources:
 - type: ARTIFACT_GROUP
@@ -88,7 +88,7 @@ sources:
     - WindowsHostsFiles
 supported_os: [Windows]
 ---
-name: LiveResponsePersistence
+name: TriagePersistence
 doc: Group of persistence mechanism related artifacts.
 sources:
 - type: ARTIFACT_GROUP
@@ -107,7 +107,7 @@ sources:
     - WindowsWinstart
 supported_os: [Windows]
 ---
-name: LiveResponseSecurityAgents
+name: TriageSecurityAgents
 doc: Group of endpoint detection and response related artifacts.
 sources:
 - type: ARTIFACT_GROUP
@@ -122,7 +122,7 @@ sources:
     - SymantecAVQuarantine
 supported_os: [Windows]
 ---
-name: LiveResponseSystemConfiguration
+name: TriageSystemConfiguration
 doc: Group of configuration files related artifacts.
 sources:
 - type: ARTIFACT_GROUP
@@ -132,7 +132,7 @@ sources:
     - WindowsSystemRegistryFilesAndTransactionLogsBackup
 supported_os: [Windows]
 ---
-name: LiveResponseSystemLogs
+name: TriageSystemLogs
 doc: Group of system logs related artifacts.
 sources:
 - type: ARTIFACT_GROUP
@@ -142,7 +142,7 @@ sources:
     - WindowsEventLogs
 supported_os: [Windows]
 ---
-name: LiveResponseWebBrowserExtensions
+name: TriageWebBrowserExtensions
 doc: Group of web browser extensions related artifacts.
 sources:
 - type: ARTIFACT_GROUP
@@ -154,7 +154,7 @@ sources:
     - FirefoxAddOns
 supported_os: [Windows]
 ---
-name: LiveResponseWebBrowserHhistory
+name: TriageWebBrowserHhistory
 doc: Group of web browser history related artifacts.
 sources:
 - type: ARTIFACT_GROUP

--- a/data/windows.yaml
+++ b/data/windows.yaml
@@ -3010,6 +3010,16 @@ sources:
 supported_os: [Windows]
 urls: ['https://www.microsoftpressstore.com/articles/article.aspx?p=2762082&seqNum=2']
 ---
+name: WindowsRDPClientBitmapCache
+doc: Artifacts of RDP connection contents
+sources:
+- type: FILE
+  attributes:
+    paths: ['%%users.localappdata%%\Microsoft\Terminal Server Client\Cache\*.*']
+    separator: '\'
+supported_os: [Windows]
+urls: ['https://forensicswiki.xyz/wiki/index.php?title=Windows#RDP_Bitmap_Cache']
+---
 name: WindowsActiveSyncAutoStart
 doc: Windows ActiveSync AutoStart entries
 sources:


### PR DESCRIPTION
A templated set of Artifact Groups that captures Windows artifacts and can be extended for Mac and Linux later. The purpose is to use those groups for Triage / Live Response analysis of systems.