### PR TITLE
Temporarily removing Windows from UsersDirectory

### DIFF
--- a/data/user.yaml
+++ b/data/user.yaml
@@ -6,7 +6,7 @@ doc: Contents of the Users directory.
 sources:
 - type: PATH
   attributes: {paths: ['/Users/*']}
-supported_os: [Darwin, Windows]
+supported_os: [Darwin]
 provides: [users.username]
 urls: ['https://forensicswiki.xyz/wiki/index.php?title=Mac_OS_X_10.9_-_Artifacts_Location#Users']
 ---


### PR DESCRIPTION
The e2e tests of GRR started to break due to the UsersDirectory supporting Windows. The issue is that this definition uses "provides: [users.username]" and the Knowledge Base used by GRR relies on it, so suddenly it has an unexpected list of users.

As a temporary solution until we figure out a better one, I'd ask that we remove the Windows support so the GRR builds can pass again.