### PR TITLE
Added Linux artifact definitions

### DIFF
--- a/data/linux.yaml
+++ b/data/linux.yaml
@@ -17,6 +17,14 @@ sources:
     - '/var/spool/anacron/cron.weekly'
 supported_os: [Linux]
 ---
+name: AptitudeLogFiles
+doc: Linux aptitude package manager log files.
+sources:
+- type: FILE
+  attributes: {paths: ['/var/log/aptitude*']}
+supported_os: [Linux]
+urls: ['https://www.debian.org/doc/manuals/aptitude/rn01re01.en.html']
+---
 name: APTSources
 doc: APT package sources list
 sources:
@@ -73,16 +81,6 @@ sources:
 - type: FILE
   attributes: {paths: ['/var/lib/dpkg/status']}
 supported_os: [Linux]
----
-name: AptitudeLogFiles
-doc: Linux aptitude package manager log files.
-sources:
-- type: FILE
-  attributes:
-    paths:
-    - '/var/log/aptitude*'
-supported_os: [Linux]
-urls: ['https://www.debian.org/doc/manuals/aptitude/rn01re01.en.html']
 ---
 name: DebianVersion
 doc: Debian version information.

--- a/data/linux.yaml
+++ b/data/linux.yaml
@@ -194,16 +194,6 @@ sources:
     - '/var/spool/cron/atspool/*'
 supported_os: [Linux]
 ---
-name: LinuxIfUpDownScripts
-doc: ifupdown scripts executed whenever a network interface goes up or down respectively.
-sources:
-- type: FILE
-  attributes:
-    paths:
-    - '/etc/network/if-up.d/*'
-    - '/etc/network/if-down.d/*'
-supported_os: [Linux]
----
 name: LinuxAuditLogs
 doc: Linux audit log files.
 sources:
@@ -321,6 +311,16 @@ doc: Linux hostname file.
 sources:
 - type: FILE
   attributes: {paths: ['/etc/hostname']}
+supported_os: [Linux]
+---
+name: LinuxIfUpDownScripts
+doc: ifupdown scripts executed whenever a network interface goes up or down respectively.
+sources:
+- type: FILE
+  attributes:
+    paths:
+    - '/etc/network/if-up.d/*'
+    - '/etc/network/if-down.d/*'
 supported_os: [Linux]
 ---
 name: LinuxInitrdFiles

--- a/data/linux.yaml
+++ b/data/linux.yaml
@@ -347,6 +347,14 @@ sources:
 supported_os: [Linux]
 urls: ['https://linux.die.net/man/5/issue']
 ---
+name: LinuxKerberosConfiguration
+doc: Linux Kerberos configuration information.
+sources:
+- type: FILE
+  attributes: {paths: ['/etc/krb5.conf']}
+supported_os: [Linux]
+urls: ['https://web.mit.edu/kerberos/krb5-1.12/doc/admin/conf_files/krb5_conf.html']
+---
 name: LinuxKernelLogFiles
 doc: Linux kernel log files.
 sources:
@@ -772,16 +780,6 @@ sources:
     - '/root/.k5login'
 supported_os: [Linux]
 ---
-name: LinuxKerberosConfiguration
-doc: Linux Kerberos configuration information.
-sources:
-- type: FILE
-  attributes:
-    paths:
-    - '/etc/krb5.conf'
-supported_os: [Linux]
-urls: ['https://web.mit.edu/kerberos/krb5-1.12/doc/admin/conf_files/krb5_conf.html']
----
 name: MySQLHistoryFile
 doc: MySQL History file.
 sources:
@@ -790,6 +788,14 @@ sources:
     paths:
     - '%%users.homedir%%/.mysql_history'
 supported_os: [Linux]
+---
+name: NanoHistoryFile
+doc: nano history file that logs search and replace strings.
+sources:
+- type: FILE
+  attributes: {paths: ['%%users.homedir%%/.nano_history']}
+supported_os: [Linux]
+urls: ['https://www.nano-editor.org/dist/v2.2/nano.html']
 ---
 name: NetgroupConfiguration
 doc: Linux netgroup configuration.
@@ -948,16 +954,6 @@ sources:
     paths:
     - '%%users.homedir%%/.viminfo'
 supported_os: [Linux]
----
-name: NanoHistoryFile
-doc: nano history file that logs search and replace strings.
-sources:
-- type: FILE
-  attributes:
-    paths:
-    - '%%users.homedir%%/.nano_history'
-supported_os: [Linux]
-urls: ['https://www.nano-editor.org/dist/v2.2/nano.html']
 ---
 name: WgetHSTSdatabase
 doc: Default wget HTTP Strict Transport Security (HSTS) database

--- a/data/linux.yaml
+++ b/data/linux.yaml
@@ -74,6 +74,16 @@ sources:
   attributes: {paths: ['/var/lib/dpkg/status']}
 supported_os: [Linux]
 ---
+name: AptitudeLogFiles
+doc: Linux aptitude package manager log files.
+sources:
+- type: FILE
+  attributes:
+    paths:
+    - '/var/log/aptitude*'
+supported_os: [Linux]
+urls: ['https://www.debian.org/doc/manuals/aptitude/rn01re01.en.html']
+---
 name: DebianVersion
 doc: Debian version information.
 sources:
@@ -169,11 +179,42 @@ sources:
     - '/etc/modprobe.d/*'
 supported_os: [Linux]
 ---
+name: LinuxUdevRules
+doc: Linux udev rules for the events received by the udev's daemon from the Linux kernel.
+sources:
+- type: FILE
+  attributes:
+    paths:
+    - '/usr/lib/udev/rules.d/*'
+    - '/etc/udev/rules.d/*'
+supported_os: [Linux]
+urls: ['https://wiki.archlinux.org/title/Udev']
+---
 name: LinuxAtJobs
 doc: Linux at jobs.
 sources:
 - type: FILE
   attributes: {paths: ['/var/spool/at/*']}
+supported_os: [Linux]
+---
+name: LinuxAtJobsTemporaryOutputs
+doc: Linux at jobs temporary outputs.
+sources:
+- type: FILE
+  attributes:
+    paths:
+    - '/var/spool/at/spool/*'
+    - '/var/spool/cron/atspool/*'
+supported_os: [Linux]
+---
+name: LinuxIfUpDownScripts
+doc: ifupdown scripts executed whenever a network interface goes up or down respectively.
+sources:
+- type: FILE
+  attributes:
+    paths:
+    - '/etc/network/if-up.d/*'
+    - '/etc/network/if-down.d/*'
 supported_os: [Linux]
 ---
 name: LinuxAuditLogs
@@ -733,6 +774,16 @@ sources:
     - '/root/.k5login'
 supported_os: [Linux]
 ---
+name: LinuxKerberosConfiguration
+doc: Linux Kerberos configuration information.
+sources:
+- type: FILE
+  attributes:
+    paths:
+    - '/etc/krb5.conf'
+supported_os: [Linux]
+urls: ['https://web.mit.edu/kerberos/krb5-1.12/doc/admin/conf_files/krb5_conf.html']
+---
 name: MySQLHistoryFile
 doc: MySQL History file.
 sources:
@@ -899,6 +950,16 @@ sources:
     paths:
     - '%%users.homedir%%/.viminfo'
 supported_os: [Linux]
+---
+name: NanoHistoryFile
+doc: nano history file that logs search and replace strings.
+sources:
+- type: FILE
+  attributes:
+    paths:
+    - '%%users.homedir%%/.nano_history'
+supported_os: [Linux]
+urls: ['https://www.nano-editor.org/dist/v2.2/nano.html']
 ---
 name: WgetHSTSdatabase
 doc: Default wget HTTP Strict Transport Security (HSTS) database

--- a/data/linux.yaml
+++ b/data/linux.yaml
@@ -177,17 +177,6 @@ sources:
     - '/etc/modprobe.d/*'
 supported_os: [Linux]
 ---
-name: LinuxUdevRules
-doc: Linux udev rules for the events received by the udev's daemon from the Linux kernel.
-sources:
-- type: FILE
-  attributes:
-    paths:
-    - '/usr/lib/udev/rules.d/*'
-    - '/etc/udev/rules.d/*'
-supported_os: [Linux]
-urls: ['https://wiki.archlinux.org/title/Udev']
----
 name: LinuxAtJobs
 doc: Linux at jobs.
 sources:
@@ -693,6 +682,17 @@ sources:
 - type: FILE
   attributes: {paths: ['/etc/timezone']}
 supported_os: [Linux]
+---
+name: LinuxUdevRules
+doc: Linux udev rules for the events received by the udev's daemon from the Linux kernel.
+sources:
+- type: FILE
+  attributes:
+    paths:
+    - '/usr/lib/udev/rules.d/*'
+    - '/etc/udev/rules.d/*'
+supported_os: [Linux]
+urls: ['https://wiki.archlinux.org/title/Udev']
 ---
 name: LinuxUtmpFiles
 doc: Linux btmp, utmp and wtmp login record files.


### PR DESCRIPTION
Adds new Linux artifact definitions:
- `udev` rules [local persistence]
- `at` jobs temporary outputs [local persistence]
- Kerberos configuration file (with Kerberos realm(s) & `KDC`) default location [system info]
- ifupdown scripts [local persistence]
- nano history file [files access]