### PR TITLE
Added supported_os to source in BashShellHistoryFile definition

### DIFF
--- a/data/shell.yaml
+++ b/data/shell.yaml
@@ -37,6 +37,7 @@ sources:
   attributes:
     paths:
     - '%%users.homedir%%/.bash_history'
+  supported_os: [Darwin, Linux]
 - type: FILE
   attributes:
     paths: ['%%users.localappdata%%\Packages\*\LocalState\rootfs\home\*\.bash_history']


### PR DESCRIPTION
'supported_os' field added for path '%%users.homedir%%/.bash_history' under BashShellHistoryFile