### PR TITLE
Modified syslog glob to match more files

### DIFF
--- a/data/linux.yaml
+++ b/data/linux.yaml
@@ -563,7 +563,7 @@ name: LinuxSysLogFiles
 doc: Linux syslog log files.
 sources:
 - type: FILE
-  attributes: {paths: ['/var/log/syslog.log*']}
+  attributes: {paths: ['/var/log/syslog*']}
 supported_os: [Linux]
 ---
 name: LinuxSyslogNgConfigs


### PR DESCRIPTION
Notably on Ubuntu, the syslog file is /var/log/syslog, not /var/log/syslog.log