### PR TITLE
adding a definition for modern macOS

### DIFF
--- a/data/webbrowser.yaml
+++ b/data/webbrowser.yaml
@@ -1267,6 +1267,8 @@ sources:
     paths:
     - '%%users.homedir%%/Library/Caches/com.apple.Safari/Cache.db'
     - '%%users.homedir%%/Library/Caches/com.apple.Safari/Cache.db-wal'
+    - '%%users.homedir%%/Library/Containers/com.apple.Safari/Data/Library/Caches/com.apple.Safari/Cache.db'
+    - '%%users.homedir%%/Library/Containers/com.apple.Safari/Data/Library/Caches/com.apple.Safari/Cache.db-wal'
   supported_os: [Darwin]
 - type: FILE
   attributes:


### PR DESCRIPTION
Updating SafariCache for more modern Cache location:

https://echoone.com/filejuicer/formats/cache#:~:text=Where%20to%20find%20the%20Cache,Library%2FCaches%2F%20)%20folder.