### PR TITLE
Change WindowsServices to include subkeys and values

### DIFF
--- a/artifacts/data/windows.yaml
+++ b/artifacts/data/windows.yaml
@@ -2343,7 +2343,7 @@ doc: Windows service and driver configurations.
 sources:
 - type: REGISTRY_KEY
   attributes:
-    keys: ['HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\*']
+    keys: ['HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\**']
 supported_os: [Windows]
 urls: ['https://artifacts-kb.readthedocs.io/en/latest/sources/windows/ServicesAndDrivers.html']
 ---


### PR DESCRIPTION
HKLM\System\CurrentControlSet\Services\ is a listing of all service names and that's about it. Adding a * includes the config data