### PR TITLE
adding W3SVC to filepath

### DIFF
--- a/artifacts/data/webservers.yaml
+++ b/artifacts/data/webservers.yaml
@@ -100,8 +100,9 @@ sources:
 - type: FILE
   attributes:
     paths:
-    - '%%environ_systemroot%%\System32\LogFiles\W3SVC*\*.log'
+    - '%%environ_systemdrive%%\inetpub\logs\LogFiles\*.log'
     - '%%environ_systemdrive%%\inetpub\logs\LogFiles\W3SVC*\*.log'
     - '%%environ_systemdrive%%\Resources\Directory\*\LogFiles\Web\W3SVC*\*.log'
+    - '%%environ_systemroot%%\System32\LogFiles\W3SVC*\*.log'
     separator: '\'
 supported_os: [Windows]

--- a/artifacts/data/webservers.yaml
+++ b/artifacts/data/webservers.yaml
@@ -101,7 +101,7 @@ sources:
   attributes:
     paths:
     - '%%environ_systemroot%%\System32\LogFiles\W3SVC*\*.log'
-    - '%%environ_systemdrive%%\inetpub\logs\LogFiles\*.log'
+    - '%%environ_systemdrive%%\inetpub\logs\LogFiles\W3SVC*\*.log'
     - '%%environ_systemdrive%%\Resources\Directory\*\LogFiles\Web\W3SVC*\*.log'
     separator: '\'
 supported_os: [Windows]


### PR DESCRIPTION
This is the default logging path for IIS on my Windows Server 2019. If it's not a typo, this should be added as a separate line.

![image](https://github.com/ForensicArtifacts/artifacts/assets/5234020/a5313191-dc02-4a96-b49f-ea4c9a6cd19b)
