### PR TITLE
Added containerd and Docker root directory path

### DIFF
--- a/artifacts/data/containerd.yaml
+++ b/artifacts/data/containerd.yaml
@@ -1,5 +1,12 @@
 # containerd artifacts
-
+---
+name: ContainerdRootDirectory
+doc: containerd default root directory.
+sources:
+- type: PATH
+  attributes:
+    paths: ['/var/lib/containerd/*']
+supported_os: [Linux]
 ---
 name: ContainerdConfig
 doc: containerd configuration files

--- a/artifacts/data/containerd.yaml
+++ b/artifacts/data/containerd.yaml
@@ -1,13 +1,5 @@
 # containerd artifacts
 ---
-name: ContainerdRootDirectory
-doc: containerd default root directory.
-sources:
-- type: PATH
-  attributes:
-    paths: ['/var/lib/containerd/*']
-supported_os: [Linux]
----
 name: ContainerdConfig
 doc: containerd configuration files
 sources:
@@ -32,4 +24,12 @@ sources:
     - '/var/log/daemon.log.*.gz'
     - '/var/log/syslog*'
     - '/var/log/message*'
+supported_os: [Linux]
+---
+name: ContainerdRootDirectory
+doc: containerd default root directory.
+sources:
+- type: PATH
+  attributes:
+    paths: ['/var/lib/containerd/*']
 supported_os: [Linux]

--- a/artifacts/data/docker.yaml
+++ b/artifacts/data/docker.yaml
@@ -1,6 +1,13 @@
 # Docker artifacts
 
 ---
+name: DockerRootDirectory
+doc: Docker default root directory.
+sources:
+- type: PATH
+  attributes:
+    paths: ['/var/lib/docker/*']
+---
 name: DockerContainerConfig
 doc: Docker container configuration files
 sources:

--- a/artifacts/data/docker.yaml
+++ b/artifacts/data/docker.yaml
@@ -1,12 +1,4 @@
 # Docker artifacts
-
----
-name: DockerRootDirectory
-doc: Docker default root directory.
-sources:
-- type: PATH
-  attributes:
-    paths: ['/var/lib/docker/*']
 ---
 name: DockerContainerConfig
 doc: Docker container configuration files
@@ -17,6 +9,13 @@ sources:
     - '/var/lib/docker/containers/*/config.v2.json'
     - '/var/lib/docker/containers/*/config.json'
 supported_os: [Linux]
+---
+name: DockerRootDirectory
+doc: Docker default root directory.
+sources:
+- type: PATH
+  attributes:
+    paths: ['/var/lib/docker/*']
 ---
 name: GKEDockerContainerLogs
 doc: Location where stdout and stderr from containers is logged in a Google Kubernetes Engine (GKE) environment.


### PR DESCRIPTION
Adding containerd and Docker root directory. This can be used by `image_export.py` to export the artifacts.