### PR TITLE
Update artifact.py

### DIFF
--- a/artifacts/artifact.py
+++ b/artifacts/artifact.py
@@ -78,7 +78,7 @@ class ArtifactDefinition(object):
           'type': source.type_indicator,
           'attributes': source.AsDict()
       }
-      if source.supported_os:
+      if getattr(source, "supported_os", None):
         source_definition['supported_os'] = source.supported_os
       sources.append(source_definition)
 


### PR DESCRIPTION
For sources the supported_os attribute is not initialized by default, therefore a test on source.supported_os might raise an AttributeError