### PR TITLE
Add extra paths for MacOS Crontab

### DIFF
--- a/artifacts/data/macos.yaml
+++ b/artifacts/data/macos.yaml
@@ -238,6 +238,8 @@ sources:
     - '/etc/crontab'
     - '/private/etc/crontab'
     - '/usr/lib/cron/tabs/*'
+    - '/var/at/tabs/*'
+    - '/var/cron/tabs/*'
 supported_os: [Darwin]
 urls: ['https://forensics.wiki/mac_os_x_10.9_artifacts_location#system-info-misc']
 ---

--- a/artifacts/data/macos.yaml
+++ b/artifacts/data/macos.yaml
@@ -238,7 +238,9 @@ sources:
     - '/etc/crontab'
     - '/private/etc/crontab'
     - '/usr/lib/cron/tabs/*'
+    - '/private/var/at/tabs/*'
     - '/var/at/tabs/*'
+    - '/private/var/cron/tabs/*'
     - '/var/cron/tabs/*'
 supported_os: [Darwin]
 urls: ['https://forensics.wiki/mac_os_x_10.9_artifacts_location#system-info-misc']


### PR DESCRIPTION
Older Mac versions store crontabs at /var/cron/tabs/* and /var/at/tabs/*  when a user runs crontab -e. 