### PR TITLE
Added Darwin as supported_os for Fish History

### DIFF
--- a/artifacts/data/shell.yaml
+++ b/artifacts/data/shell.yaml
@@ -114,8 +114,8 @@ doc: Fish shell (fish) history files.
 sources:
 - type: FILE
   attributes: {paths: ['%%users.homedir%%/.local/share/fish/fish_history']}
-  supported_os: [Linux]
-supported_os: [Linux]
+  supported_os: [Darwin, Linux]
+supported_os: [Darwin, Linux]
 urls: ['https://fishshell.com/docs/current/cmds/history.html']
 ---
 name: KornShellConfigurationFile


### PR DESCRIPTION
Some Darwin systems use Fish shell. This PR adds support for the OS.