### PR TITLE
Clarify documentation on `REGISTRY_KEY` source

### DIFF
--- a/docs/sources/Format-specification.md
+++ b/docs/sources/Format-specification.md
@@ -230,21 +230,22 @@ separator | Optional path segment separator e.g. '\' for Windows systems. When n
 ### Windows Registry key source
 
 The Windows Registry key source is a source that consists of the contents of
-Windows Registry keys e.g.
+Windows Registry keys (where _contents_ is its subkeys, values and class name)
+e.g.
 
 ```yaml
 sources:
 - type: REGISTRY_KEY
   attributes:
     keys:
-    - 'HKEY_USERS\%%users.sid%%\Software\Microsoft\Internet Explorer\TypedURLs\*'
+    - 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\*'
 ```
 
 Where `attributes` can contain the following values:
 
 Value | Description
 --- | ---
-keys | A list of Windows Registry key paths that can potentially be collected. The paths can use parameter expansion e.g. `%%users.sid%%`. See section: [Parameter expansion and globs](parameter-expansion-and-globs).
+keys | A list of Windows Registry key paths that can potentially be collected. The paths can use parameter expansion e.g. `%%users.sid%%` and globs. See section: [Parameter expansion and globs](parameter-expansion-and-globs).
 
 ### Windows Registry value source
 


### PR DESCRIPTION
Registry key _contents_ is quite ambiguous (and means something different from registry value contents), so the wording is clarified after consulting with @joachimmetz.

Furthermore, this also fixes the example that is not consistent with the description of the `keys` attribute:

> A list of Windows Registry key paths (...)

I verified on my machine and `HKEY_USERS\*\Software\Microsoft\Internet Explorer\TypedURLs` users contains no subkeys, only values (e.g. `url1` with content `http://go.microsoft.com/fwlink/p/?LinkId=255141`). Thus, the glob here will match no _key_.

`HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths` proposed here on the other hand contains multiple subkeys (e.g. `chrome.exe`, `pwsh.exe`, `mplayer2.exe`) which contain values specifying the path (but are not consistent: some do it through the default value, some do it through value named `Path`).