### PR TITLE
Changes to WindowsUserShellFolders definition

### DIFF
--- a/artifacts/data/windows.yaml
+++ b/artifacts/data/windows.yaml
@@ -3327,8 +3327,9 @@ sources:
 - type: REGISTRY_KEY
   attributes:
     keys:
-    - 'HKEY_USERS\%%users.sid%%\Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders\*'
-    - 'HKEY_USERS\%%users.sid%%\Environment\*'
+    - 'HKEY_USERS\%%users.sid%%\Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders'
+    - 'HKEY_USERS\%%users.sid%%\Environment'
+    - 'HKEY_USERS\%%users.sid%%\Volatile Environment'
     - 'HKEY_USERS\%%users.sid%%\Volatile Environment\*'
 supported_os: [Windows]
 ---

--- a/artifacts/data/windows.yaml
+++ b/artifacts/data/windows.yaml
@@ -3328,9 +3328,10 @@ sources:
   attributes:
     keys:
     - 'HKEY_USERS\%%users.sid%%\Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders'
+    - 'HKEY_USERS\%%users.sid%%\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders'
+    - 'HKEY_USERS\%%users.sid%%\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders\New'
     - 'HKEY_USERS\%%users.sid%%\Environment'
     - 'HKEY_USERS\%%users.sid%%\Volatile Environment'
-    - 'HKEY_USERS\%%users.sid%%\Volatile Environment\*'
 supported_os: [Windows]
 ---
 name: WindowsWebCacheStorageQuotaDatabaseFile


### PR DESCRIPTION
Based on the clarification in #662, I fixed the `WindowsUserShellFolders` artifact: `HKEY_USERS\%%users.sid%%\Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders` and `HKEY_USERS\%%users.sid%%\Environment` contain no subkeys, only values, so the glob at the end of the `keys` attribute will match nothing. `HKEY_USERS\%%users.sid%%\Volatile Environment` is a bit different as it contains both values and subkeys (with values), so the glob makes sense given we also include the key itself.