### PR TITLE
Fix: missing whitespace in unix_common.yaml

### DIFF
--- a/artifacts/data/unix_common.yaml
+++ b/artifacts/data/unix_common.yaml
@@ -11,7 +11,7 @@ sources:
   attributes: {paths: ['/private/var/spool/cups/cache/job.cache']}
   supported_os: [Darwin]
 - type: FILE
-  attributes: {paths:['/var/cache/cups/job.cache']}
+  attributes: {paths: ['/var/cache/cups/job.cache']}
   supported_os: [Linux]
 supported_os: [Darwin, Linux]
 urls:


### PR DESCRIPTION
Whitespace was missing, leading to invalid YAML for one of the FILE sources of CupsJobCacheFile